### PR TITLE
Add configurable Adam parameters, set beta2 to 0.95

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -109,7 +109,8 @@ prompt: "I love to "
 enable_profiler: False
 enable_checkpointing: True
 
+# Adam optimizer parameters
 adam_b1: 0.9 # Exponential decay rate to track the first moment of past gradients.
 adam_b2: 0.95 # Exponential decay rate to track the second moment of past gradients.
 adam_eps: 1.e-8 # A small constant applied to denominator outside of the square root.
-adam_eps_root: 0. # A small constant applied to denominator inside the square root
+adam_eps_root: 0. # A small constant applied to denominator inside the square root.

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -109,3 +109,7 @@ prompt: "I love to "
 enable_profiler: False
 enable_checkpointing: True
 
+adam_b1: 0.9 # Exponential decay rate to track the first moment of past gradients.
+adam_b2: 0.95 # Exponential decay rate to track the second moment of past gradients.
+adam_eps: 1.e-8 # A small constant applied to denominator outside of the square root.
+adam_eps_root: 0. # A small constant applied to denominator inside the square root

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -289,7 +289,11 @@ def train_loop(config, state=None):
   tx = optax.adam(
       max_utils.create_learning_rate_schedule(
           learning_rate=config.learning_rate, warmup_steps=config.warmup_steps
-      )
+      ),
+      b1=config.adam_b1,
+      b2=config.adam_b2,
+      eps=config.adam_eps,
+      eps_root=config.adam_eps_root
   )
 
   # Mesh definition


### PR DESCRIPTION
This change:
* Allows users to overwrite default Adam optimizer parameters
* Sets the Maxtext default beta2 to a much stabler (less training loss spikes) value of 0.95 instead of default 0.999

Before this change 17B model with default beta2=0.999
![Pre-beta-instability](https://user-images.githubusercontent.com/51136315/234942289-e4370b52-983e-46cd-92f0-f79ef6094dbe.png)

After this change 17B model with beta2=0.95
![post-beta-stability](https://user-images.githubusercontent.com/51136315/234943050-478237e9-e611-40c4-bc93-8c4400d0658f.png)

