### PR TITLE
Call jax.device_count at start to solve TPU already registered issue

### DIFF
--- a/MaxText/checkpointing.py
+++ b/MaxText/checkpointing.py
@@ -25,7 +25,7 @@ try: #TODO(migrate to updated API fully once it is universally available)
 except ImportError:
   from jax._src.clusters.cloud_tpu_cluster import get_metadata
 from orbax import checkpoint
-from orbax.checkpoint.checkpoint_manager import CheckpointManager, CheckpointManagerOptions, Checkpointer, AsyncCheckpointer
+from orbax.checkpoint.checkpoint_manager import CheckpointManager, CheckpointManagerOptions, Checkpointer
 from orbax.checkpoint import type_handlers
 
 import max_logging
@@ -58,14 +58,13 @@ def create_orbax_checkpoint_manager(checkpoint_dir: str, enable_checkpointing: b
   if not enable_checkpointing:
     max_logging.log("Checkpointing disabled, not creating checkpoint manager.")
     return None
-  max_logging.log("Creating checkpoint manager...")
-  _multislice_distribute_initialize()
+  max_logging.log("Started checkpointing")
+  #_multislice_distribute_initialize()
   p = epath.Path(checkpoint_dir)
-  ckpt_mngr = CheckpointManager(p,
-                           AsyncCheckpointer(checkpoint.PyTreeCheckpointHandler()),
+
+  return CheckpointManager(p,
+                           Checkpointer(checkpoint.PyTreeCheckpointHandler()),
                            options = CheckpointManagerOptions(create=True))
-  max_logging.log("Checkpoint manager created!")
-  return ckpt_mngr
 
 
 def load_state_if_possible(checkpoint_manager: CheckpointManager,

--- a/MaxText/checkpointing.py
+++ b/MaxText/checkpointing.py
@@ -25,7 +25,7 @@ try: #TODO(migrate to updated API fully once it is universally available)
 except ImportError:
   from jax._src.clusters.cloud_tpu_cluster import get_metadata
 from orbax import checkpoint
-from orbax.checkpoint.checkpoint_manager import CheckpointManager, CheckpointManagerOptions, Checkpointer
+from orbax.checkpoint.checkpoint_manager import CheckpointManager, CheckpointManagerOptions, Checkpointer, AsyncCheckpointer
 from orbax.checkpoint import type_handlers
 
 import max_logging
@@ -58,13 +58,14 @@ def create_orbax_checkpoint_manager(checkpoint_dir: str, enable_checkpointing: b
   if not enable_checkpointing:
     max_logging.log("Checkpointing disabled, not creating checkpoint manager.")
     return None
-  max_logging.log("Started checkpointing")
-  #_multislice_distribute_initialize()
+  max_logging.log("Creating checkpoint manager...")
+  _multislice_distribute_initialize()
   p = epath.Path(checkpoint_dir)
-
-  return CheckpointManager(p,
-                           Checkpointer(checkpoint.PyTreeCheckpointHandler()),
+  ckpt_mngr = CheckpointManager(p,
+                           AsyncCheckpointer(checkpoint.PyTreeCheckpointHandler()),
                            options = CheckpointManagerOptions(create=True))
+  max_logging.log("Checkpoint manager created!")
+  return ckpt_mngr
 
 
 def load_state_if_possible(checkpoint_manager: CheckpointManager,

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -19,8 +19,6 @@ run_name: ""
 # If we aren't resuming from an existing checkpoint, load parameters from this path if provided.
 load_parameters_path: ""
 
-use_pjrt: "true"
-mxla_barrier: "true"
 reuse_example_batch: 0 # for testing TPU performance, this options repeated uses the same batch.
 
 metrics_file: "" # for testing, local file that stores scalar metrics. If empty, no metrics are written.

--- a/MaxText/multihost_dataloading.py
+++ b/MaxText/multihost_dataloading.py
@@ -30,7 +30,6 @@ import time
 import numpy as np
 
 import jax
-from jax.experimental import global_device_array as gda_lib
 from jax.experimental import PartitionSpec
 from jax.experimental.maps import Mesh
 

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -14,7 +14,7 @@
  limitations under the License.
  """
 
-# pylint: disable=g-bad-todo, abstract-method, consider-using-with
+# pylint: disable=g-bad-todo, abstract-method, consider-using-with, ungrouped-imports
 """Training loop and Decoding of the model."""
 
 # Calling jax.devces here prevents a "TPU platform already registered" error.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-jax[tpu]==0.4.8
-orbax-checkpoint==0.2.1
+jax[tpu]
+orbax-checkpoint
 absl-py
 argparse
 datetime
@@ -9,12 +9,12 @@ ml-collections
 numpy
 optax
 portpicker
-protobuf==3.20.3
+protobuf
 pylint
 pytest
 sentencepiece==0.1.97
-tensorflow==2.12.0rc0
+tensorflow
 tensorflow-datasets
 tensorboard-plugin-profile
-tensorflow-text==2.12.0rc0
+tensorflow-text
 tensorboardx

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-jax[tpu]==0.4.6
-orbax==0.1.6
+jax[tpu]==0.4.8
+orbax-checkpoint==0.2.1
 absl-py
 argparse
 datetime


### PR DESCRIPTION
* Add jax.(device_count) at start to prevent flakes in https://github.com/google/maxtext/issues/20
* Also remove init_train_state from main since it is unreferenced - it is actually called in max_utils
* Unpin all requirements (except for sentencepiece)
* In particular this has the effect of upgrading jax to 0.4.8 and orbax to orbax-checkpoint 0.2.1

Tested via:
* 15 sync checkpoint runs on 2xv4-8(save 2x, load 1x)
* A 1.75B model on 1xv4-128 that gets 172 MFU