### PR TITLE
Reinstate internal-ip and remove gcloud auth login

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ either be a TPUVM or not. If your runner machine is a TPUVM, it needs service ac
 
 5. View the job's logs in cloud logging. 
 
-    The link to your job's cloud logging is printed at the end of `multihost_job` output. Additionaly logs are saved to GCS when your job finished, the bucket's URL is also printed by `multihost_job`.
+    The link to your job's cloud logging is printed at the end of `multihost_job` output. Additionaly logs are saved to GCS when your job finishes, and this bucket's URL is also printed by `multihost_job`.
 
 6. Cleanup the QR when finished.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ bash download_dataset.sh {GCS_PROJECT} {GCS_BUCKET_NAME}
 ```
 3. Change config values for `base_output_directory` and `dataset_path` in `configs/base.yml`. `vocab_relative_path` is relative to `base_output_directory` for loading the tokenizer. MaxText assumes these GCS buckets are created in the same project and that it has permissions to read and write from them. We also recommend reviewing the configurable options in `configs/base.yml`, for instance you may change the `steps` or `logging_period` by either modifying `configs/base.yml` or by passing in `steps` and `logging_period` as additional args to the `train.py` call.
 
+To run maxtext the TPUVMs must have permission to read the gcs bucket. These permissions are granted by service account roles, such as the `STORAGE ADMIN` role. 
+
 ## Getting Started: Local Development
 
 Local development is the faster and most convenient way to run MaxText. However, it doesn't scale to multiple hosts.
@@ -80,14 +82,9 @@ The `multihost_runner.py` script:
 Although there are several steps below, most are for the initial setup. Once setup you can continually make changes to your code and re-run your code with only step 5.
 
 1. Choose a directory on your runner machine to develop and clone MaxText into. The runner machine can 
-either be a TPUVM or not, but it cannot be one of the workers. Clone MaxText, and cd into the root of the repo.
+either be a TPUVM or not, but it cannot be one of the workers. If your runner machine is a TPUVM, it needs service account roles that grant it permission to create queued resources and ssh into them, such as the TPU ADMIN role.Clone MaxText, and cd into the root of the repo.
 
-2. Set your project, zone, gcloud permissions and ssh keys.
-
-    Authorize gcloud to access the Cloud Platform with Google user credentials
-    ```
-    gcloud auth login
-    ```
+2. Set your project, zone, and ssh keys.
 
     Set your gcloud config, see https://cloud.google.com/sdk/gcloud/reference/config for more.
     ```

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ either be a TPUVM or not, but it cannot be one of the workers. If your runner ma
     gcloud config set compute/zone $ZONE
     ```
 
-    Create ssh keys for gcloud, we recommend leaving a blank password (hit enter twice after running the below command)
+    Create ssh keys for gcloud, we recommend leaving a blank password (hit enter twice after running the below command), and you can choose not to overwrite (n) if you are prompted that the the file already exists.
     ```
     ssh-keygen -f ~/.ssh/google_compute_engine 
     ```

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ either be a TPUVM or not. If your runner machine is a TPUVM, it needs service ac
 
 4. Run your training job.
 
-    *** IMPORTANT *** `multihost_job` creates a request for new capacity for each run! You cannot this tool on existing capacity, instead we recommend `multihost_runner` for this purpose.
+    *** IMPORTANT *** `multihost_job` creates a request for new capacity for each run! You cannot use this tool on existing capacity, instead we recommend `multihost_runner` for this purpose.
 
     Choose the number of nodes (we use 2 below, but you may customize this and other feature of your TPU(s))
     ```
@@ -212,15 +212,14 @@ either be a TPUVM or not. If your runner machine is a TPUVM, it needs service ac
     ```
     ```
     RUN_NAME=${USER}_$(date +%Y-%m-%d-%H-%M-%S) # You may set this to any unique name for a fresh run.
-    python3 multihost_job.py --NUM_SLICES=$NODE_COUNT --RUN_NAME=$RUN_NAME --BUCKET_NAME=$BUCKET_NAME --COMMAND="bash setup.sh && python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME dcn_data_parallelism=$NODE_COUNT"
+    python3 multihost_job.py --NUM_SLICES=$NODE_COUNT --RUN_NAME=$RUN_NAME --BUCKET_NAME=$BUCKET_NAME --RESOURCE_POOL=reserved --COMMAND="bash setup.sh && python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME dcn_data_parallelism=$NODE_COUNT"
     ```
 
-    By default `multihost_job` creates a queued-resource targeting the `on-demand` pool, but you may instead
-    target the `reserved` pool by including `--RESOURCE_POOL=reserved`, or the pre-emptible pool with `--RESOURCE_POOL=best-effot`. 
+    We tell `multihost_job` to target the `reserved` pool by  by including `--RESOURCE_POOL=reserved`, but you may instead target the `on-demand` pool by removing the `--RESOURCE_POOL` flag, or the pre-emptible pool with `--RESOURCE_POOL=best-effot`, which may be necessary if your reservation is full.
 
 5. View the job's logs in cloud logging. 
 
-    The link to your job's cloud logging is printed at the end of `multihost_job` output. Additionaly logs are saved to GCS when your job finished, whose bucket's URL is also printed by `multihost_job`.
+    The link to your job's cloud logging is printed at the end of `multihost_job` output. Additionaly logs are saved to GCS when your job finished, the bucket's URL is also printed by `multihost_job`.
 
 6. Cleanup the QR when finished.
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The `multihost_runner.py` script:
 Although there are several steps below, most are for the initial setup. Once setup you can continually make changes to your code and re-run your code with only step 5.
 
 1. Choose a directory on your runner machine to develop and clone MaxText into. The runner machine can 
-either be a TPUVM or not, but it cannot be one of the workers. If your runner machine is a TPUVM, it needs service account roles that grant it permission to create queued resources and ssh into them, such as the TPU ADMIN role.Clone MaxText, and cd into the root of the repo.
+either be a TPUVM or not, but it cannot be one of the workers. If your runner machine is a TPUVM, it needs service account roles that grant it permission to create queued resources and ssh into them, such as the `TPU ADMIN` role. Clone MaxText, and cd into the root of the repo.
 
 2. Set your project, zone, and ssh keys.
 
@@ -125,6 +125,7 @@ either be a TPUVM or not, but it cannot be one of the workers. If your runner ma
     ```
     python3 multihost_runner.py --TPU_PREFIX=$TPU_PREFIX --COMMAND="bash setup.sh" # Dependencies of MaxText/train.py
     ```
+    If you are running the `multihost_runner.py` script from a TPUVM, you will need to set `--INTERNAL_TPU=true`.
 
 5. Run your training job.
 
@@ -135,6 +136,7 @@ either be a TPUVM or not, but it cannot be one of the workers. If your runner ma
     ```
     python3 multihost_runner.py --TPU_PREFIX=$TPU_PREFIX --COMMAND="python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME dcn_data_parallelism=$NODE_COUNT"
     ```
+    If you are running the `multihost_runner.py` script from a TPUVM, you will need to set `--INTERNAL_TPU=true`.
 
 6. Clean up TPUs and QR when finished.
 
@@ -172,14 +174,9 @@ The `multihost_job.py` script:
 * Delete the TPUs at the end of the job.
 
 1. Choose a directory on your runner machine to develop and clone MaxText into. The runner machine can 
-either be a TPUVM or not. Clone MaxText, and cd into the root of the repo.
+either be a TPUVM or not. If your runner machine is a TPUVM, it needs service account roles that grant it permission to create queued resources and has write access to GCS, such as the `TPU ADMIN` and `STORAGE ADMIN` roles. Clone MaxText, and cd into the root of the repo.
 
-2. Set your project, zone, and gcloud permissions. 
-     Authorize gcloud to access the Cloud Platform with Google user credentials
-    ```
-    gcloud auth login
-    ```
-
+2. Set your project, zone. 
     Set your gcloud config, see https://cloud.google.com/sdk/gcloud/reference/config for more.
     ```
     PROJECT=<project>

--- a/README.md
+++ b/README.md
@@ -124,9 +124,10 @@ either be a TPUVM or not, but it cannot be one of the workers. If your runner ma
     ```
     gcloud alpha compute tpus queued-resources list --filter=$QR_ID 
     ```
-4. Install dependencies. 
+4. Install dependencies.
+    Install the dependencies of `train.py` on each worker using `multihost_runner.py`:
     ```
-    python3 multihost_runner.py --TPU_PREFIX=$TPU_PREFIX --COMMAND="bash setup.sh" # Dependencies of MaxText/train.py
+    python3 multihost_runner.py --TPU_PREFIX=$TPU_PREFIX --COMMAND="bash setup.sh"
     ```
     If you are running the `multihost_runner.py` script from a TPUVM, you will need to set `--INTERNAL_TPU=true`.
 
@@ -217,9 +218,9 @@ either be a TPUVM or not. If your runner machine is a TPUVM, it needs service ac
     By default `multihost_job` creates a queued-resource targeting the `on-demand` pool, but you may instead
     target the `reserved` pool by including `--RESOURCE_POOL=reserved`, or the pre-emptible pool with `--RESOURCE_POOL=best-effot`. 
 
-5. View the job's logs in your GCS bucket. 
+5. View the job's logs in cloud logging. 
 
-    The link to your job's logs is printed at the end of the multihost_job output. They are located in BUCKET_NAME/BUCKET_PATH/RUN_NAME.
+    The link to your job's cloud logging is printed at the end of `multihost_job` output. Additionaly logs are saved to GCS when your job finished, whose bucket's URL is also printed by `multihost_job`.
 
 6. Cleanup the QR when finished.
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ either be a TPUVM or not, but it cannot be one of the workers. If your runner ma
     ```
     python3 multihost_runner.py --TPU_PREFIX=$TPU_PREFIX --COMMAND="bash setup.sh"
     ```
-    If you are running the `multihost_runner.py` script from a TPUVM, you will need to set `--INTERNAL_TPU=true`.
+    If you are running the `multihost_runner.py` script from a TPUVM, you will need to set `--INTERNAL_IP=true`.
 
 5. Run your training job.
 
@@ -140,7 +140,7 @@ either be a TPUVM or not, but it cannot be one of the workers. If your runner ma
     ```
     python3 multihost_runner.py --TPU_PREFIX=$TPU_PREFIX --COMMAND="python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME dcn_data_parallelism=$NODE_COUNT"
     ```
-    If you are running the `multihost_runner.py` script from a TPUVM, you will need to set `--INTERNAL_TPU=true`.
+    If you are running the `multihost_runner.py` script from a TPUVM, you will need to set `--INTERNAL_IP=true`.
 
 6. Clean up TPUs and QR when finished.
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ either be a TPUVM or not, but it cannot be one of the workers. If your runner ma
     gcloud config set compute/zone $ZONE
     ```
 
-    Create ssh keys for gcloud, we recommend leaving a blank password (hit enter twice after running the below command). If you are prompted that the the file already existsand you can choose not to overwrite by selecting "n".
+    Create ssh keys for gcloud, we recommend leaving a blank password (hit enter twice after running the below command). If you are prompted that the the file already exists you can choose not to overwrite by selecting "n".
     ```
     ssh-keygen -f ~/.ssh/google_compute_engine 
     ```

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ either be a TPUVM or not, but it cannot be one of the workers. If your runner ma
     gcloud config set compute/zone $ZONE
     ```
 
-    Create ssh keys for gcloud, we recommend leaving a blank password (hit enter twice after running the below command), and you can choose not to overwrite (n) if you are prompted that the the file already exists.
+    Create ssh keys for gcloud, we recommend leaving a blank password (hit enter twice after running the below command). If you are prompted that the the file already existsand you can choose not to overwrite by selecting "n".
     ```
     ssh-keygen -f ~/.ssh/google_compute_engine 
     ```
@@ -118,7 +118,7 @@ either be a TPUVM or not, but it cannot be one of the workers. If your runner ma
     gcloud alpha compute tpus queued-resources create $QR_ID --accelerator-type=v4-8 --runtime-version=tpu-vm-v4-base --node-count=$NODE_COUNT --node-prefix=$TPU_PREFIX  --reserved
     ```
     We target the `reserved` pool above, but you may instead target the `on-demand` pool by omitting this flag,
-    or target pre-emptible capacity with the `--best-effort` flag, which may be necessary if you're reservation is full.
+    or target pre-emptible capacity with the `--best-effort` flag, which may be necessary if your reservation is full.
  
     You have to wait to for the QR to become `ACTIVE` (as opposed to `ACCEPTED` or `PROVISIONING`) which corresponds to the worker nodes becoming `READY` (as opposed to `CREATING`). This may take a minute or two and can be checked via
     ```
@@ -214,7 +214,7 @@ either be a TPUVM or not. If your runner machine is a TPUVM, it needs service ac
     python3 multihost_job.py --NUM_SLICES=$NODE_COUNT --RUN_NAME=$RUN_NAME --BUCKET_NAME=$BUCKET_NAME --COMMAND="bash setup.sh && python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME dcn_data_parallelism=$NODE_COUNT"
     ```
 
-    By default `multihoist_job` creates a queued-resource targeting the `on-demand` pool, but you may instead
+    By default `multihost_job` creates a queued-resource targeting the `on-demand` pool, but you may instead
     target the `reserved` pool by including `--RESOURCE_POOL=reserved`, or the pre-emptible pool with `--RESOURCE_POOL=best-effot`. 
 
 5. View the job's logs in your GCS bucket. 

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -40,10 +40,8 @@ Example usages:
     --SCRIPT_DIR=path/to/dir --PROJECT=<my-project> --ZONE=<zone> \
     --VERSION=tpu-vm-v4-base --TPU_TYPE=v4-8 --NUM_SLICES=2 --RUN_NAME=$USER-run-job
 Common issues:
-  You must be able to communicate with the BUCKET_NAME e.g. via gsutil. You may have to run
-  gcloud auth login
-  and
-  gcloud auth application-default login
+  You must be able to communicate with the BUCKET_NAME e.g. via gsutil. If you are running this script from
+  a TPUVM this permission is achieved through Service Account roles, such as Storage Object Admin.
 """
 import argparse
 import sys

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -41,7 +41,7 @@ Example usages:
     --VERSION=tpu-vm-v4-base --TPU_TYPE=v4-8 --NUM_SLICES=2 --RUN_NAME=$USER-run-job
 Common issues:
   You must be able to communicate with the BUCKET_NAME e.g. via gsutil. If you are running this script from
-  a TPUVM this permission is achieved through Service Account roles, such as Storage Object Admin.
+  a TPUVM this permission is achieved through service account roles, such as Storage Object Admin.
 """
 import argparse
 import sys

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -40,8 +40,8 @@ Example usages:
     --SCRIPT_DIR=path/to/dir --PROJECT=<my-project> --ZONE=<zone> \
     --VERSION=tpu-vm-v4-base --TPU_TYPE=v4-8 --NUM_SLICES=2 --RUN_NAME=$USER-run-job
 Common issues:
-  You must be able to communicate with the BUCKET_NAME e.g. via gsutil. If you are running this script from
-  a TPUVM this permission is achieved through service account roles, such as Storage Object Admin.
+  You must have local write permissions to BUCKET_NAME. The allocated TPUVMs must also have read permissions to this
+  bucket, which is granted through service account roles, such as Storage Object Admin.
 """
 import argparse
 import sys

--- a/multihost_runner.py
+++ b/multihost_runner.py
@@ -45,7 +45,6 @@ import time
 from datetime import datetime
 import os
 import re
-import socket
 
 ##### Define flags #####
 parser = argparse.ArgumentParser(description='TPU configuration options')
@@ -63,7 +62,7 @@ parser.add_argument('--RUN_NAME', type=str, default=None,
 parser.add_argument('--USE_EXISTING_FOLDER', type=str, default="False",
                     help='If true, use the existing code directory on the TPU')
 parser.add_argument('--INTERNAL_TPU', type=str, default="False",
-                    help="Set true if running script locally from a TPU in the same network, false otherwise.")
+                    help="Set true if running script locally from a TPU or GCE instance, false otherwise.")
 args = parser.parse_args()
 args.USE_EXISTING_FOLDER = args.USE_EXISTING_FOLDER.lower() == "true"
 args.INTERNAL_TPU = args.INTERNAL_TPU.lower() == "true"

--- a/multihost_runner.py
+++ b/multihost_runner.py
@@ -15,7 +15,7 @@
  """
 
 # pylint: disable=consider-using-with
-""" Script to run a job in a multislice/multihost environment
+""" Script to run a command in a multislice/multihost environment
 
 The "runner" host (the one which runs this script) and the "worker" hosts (the TPUS found by --TPU_PREFIX and
 where the --COMMAND is run) should be different. You can use either a TPUVM or a non-TPUVM runner host,

--- a/multihost_runner.py
+++ b/multihost_runner.py
@@ -61,11 +61,11 @@ parser.add_argument('--RUN_NAME', type=str, default=None,
                     help="Name for the code directory on the TPU")
 parser.add_argument('--USE_EXISTING_FOLDER', type=str, default="False",
                     help='If true, use the existing code directory on the TPU')
-parser.add_argument('--INTERNAL_TPU', type=str, default="False",
+parser.add_argument('--INTERNAL_IP', type=str, default="False",
                     help="Set true if running script locally from a TPU or GCE instance, false otherwise.")
 args = parser.parse_args()
 args.USE_EXISTING_FOLDER = args.USE_EXISTING_FOLDER.lower() == "true"
-args.INTERNAL_TPU = args.INTERNAL_TPU.lower() == "true"
+args.INTERNAL_IP = args.INTERNAL_IP.lower() == "true"
 
 if not args.TPU_PREFIX:
   raise ValueError("--TPU_PREFIX must be a non-empty string specifying your TPU slice names.")
@@ -271,7 +271,7 @@ def run_commands(commands, id_to_print, jobname, worker_list, is_shell=False, ou
 
     if seconds_elapsed >= 60 and not 0 in returncodes and jobname == "SCP":
       print("SCP operation timed out - terminating all processes."\
-        " Please check that --INTERNAL_TPU flag is set correctly.")
+        " Please check that --INTERNAL_IP flag is set correctly.")
       for child in children:
         child.terminate()
       max_returncode = 255


### PR DESCRIPTION
* Reinstate explicit internal-ip flag, the previous auto-determination only works using "gcloud auth login" with an @google.com address
* Various permission and API improvements in the readme