### PR TITLE
Decode xlml

### DIFF
--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -14,7 +14,7 @@
  limitations under the License.
  """
 
-# pylint: disable=g-bad-todo, abstract-method
+# pylint: disable=g-bad-todo, abstract-method, consider-using-with
 """Training loop and Decoding of the model."""
 import functools
 from typing import Sequence

--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -173,12 +173,10 @@ def decode_loop(config, state=None):
   tokenized_prompts = encode_strings(
       [config.prompt], config.max_predict_length, sp_tokenizer)
 
-  max_utils.activate_profiler(config)
-
   if config.metrics_file:
     local_metrics_file = open(config.metrics_file, 'a', encoding="utf8")
     metrics= {'scalar': {} }
-
+  max_utils.activate_profiler(config)
   for step in np.arange(config.steps):
     rng, rng_to_use = jax.random.split(rng)
     with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):

--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -175,7 +175,9 @@ def decode_loop(config, state=None):
 
   max_utils.activate_profiler(config)
 
-  local_metrics_file = open(config.metrics_file, 'a', encoding="utf8") if config.metrics_file else None
+  if config.metrics_file:
+    local_metrics_file = open(config.metrics_file, 'a', encoding="utf8")
+    metrics= {'scalar': {} }
 
   for step in np.arange(config.steps):
     rng, rng_to_use = jax.random.split(rng)
@@ -185,14 +187,13 @@ def decode_loop(config, state=None):
       max_logging.log(f"Decoding #{step} (num tokens {num_tokens_decoded}):\n\t{decoded_string}")
       if config.metrics_file:
         metrics['scalar']['num_tokens'] = num_tokens_decoded
-        max_utils.write_metrics_locally(metrics, step, local_metrics_file)
+        max_utils.write_metrics_locally(metrics, step, pyconfig.config.steps-1, local_metrics_file)
   max_utils.deactivate_profiler(config)
 
 
 
 def main(argv: Sequence[str]) -> None:
   pyconfig.initialize(argv)
-  os.environ["JAX_USE_PJRT_C_API_ON_TPU"] = pyconfig.config.use_pjrt
   decode_loop(pyconfig.config)
 
 

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -27,6 +27,7 @@ from jax.experimental import mesh_utils
 
 from jax.experimental.pjit import pjit
 
+import json
 import flax
 from flax.training import train_state
 from flax import linen as nn
@@ -49,6 +50,18 @@ def deactivate_profiler(config):
   if config.enable_profiler:
     jax.profiler.stop_trace()
 
+def write_metrics_locally(metrics, step, last_step, file):
+  """Writes metrics locally for testing"""
+  if step == 0:
+    file.truncate(0)
+
+  aux = {}
+  for val in metrics['scalar']:
+    aux[val] = float(metrics['scalar'][val])
+  file.write(str(json.dumps(aux))+'\n')
+
+  if step == last_step:
+    file.close()
 
 def create_device_mesh(config):
   """Creates a device mesh with each slice in its own data parallel group. If there is only one slice, uses two replicas """

--- a/end_to_end/eval_assert.py
+++ b/end_to_end/eval_assert.py
@@ -21,12 +21,11 @@ def read(metrics_file, target):
   return avg
 
 
-def test_tflops(metrics_file, target, threshold):
-  """Asserts over tflops values"""
-  avg_tflops = read(metrics_file, target)
-  # Checks for acceptable performance by asserting that average tflops value
-  # is greater than or equal to threshold
-  assert avg_tflops >= threshold
+def assert_metric_average(metrics_file, target, threshold):
+  avg_value = read(metrics_file, target)
+  # Checks for acceptable performance by asserting that average metric (e.g. TFLOPs)
+  # is greater than the threshold
+  assert avg_value >= threshold
 
 
 def test_checkpointing(metrics_file, target):
@@ -47,8 +46,8 @@ def main(argv: Sequence[str]) -> None:
 
   _, metrics_file, threshold, target, test_scenario = argv
 
-  if test_scenario == 'performance':
-    test_tflops(metrics_file, target, float(threshold))
+  if test_scenario == 'metrics_average':
+    assert_metric_average(metrics_file, target, float(threshold))
   elif test_scenario == 'checkpoint_save_restore':
     test_checkpointing(metrics_file, target)
 

--- a/end_to_end/eval_assert.py
+++ b/end_to_end/eval_assert.py
@@ -12,6 +12,7 @@ def read(metrics_file, target):
   with open(metrics_file, 'r', encoding='utf8') as file:
     lines = file.readlines()
     for line in lines:
+      # skip the first 10 lines for burn in
       if i >= 10:
         vals = json.loads(line)
         avg += vals[target]
@@ -23,8 +24,9 @@ def read(metrics_file, target):
 
 def assert_metric_average(metrics_file, target, threshold):
   avg_value = read(metrics_file, target)
-  # Checks for acceptable performance by asserting that average metric (e.g. TFLOPs)
-  # is greater than the threshold
+  # Checks for acceptable performance by asserting that the average metric (e.g. TFLOPs)
+  # is greater than the threshold.
+  print(f'avg value of target {target} is {avg_value}')
   assert avg_value >= threshold
 
 

--- a/end_to_end/test_decode_v4_8_one_slice.sh
+++ b/end_to_end/test_decode_v4_8_one_slice.sh
@@ -1,24 +1,22 @@
 #!/bin/bash
 set -e
 
-USER=${1}
-NUM_TOKEN_THRESHOLD=${2}
-OUTPUT_PATH=${3}
-DATASET_PATH=${4}
-# Run name is optional 5th input - our daily XLML tests will use one.
+NUM_TOKEN_THRESHOLD=${1}
+OUTPUT_PATH=${2}
+# Run name is optional 3rd input - our daily XLML tests will use one.
 
 
-if [ -z ${5} ]
+if [ -z ${3} ]
 then 
     RUN_NAME=${USER}_$(date +%Y-%m-%d-%H-%M-%S)
 else
-    RUN_NAME=${5}_$(date +%Y-%m-%d-%H)
+    RUN_NAME=${3}_$(date +%Y-%m-%d-%H)
 fi
 
 #Setup and Train
 bash setup.sh
 python3 MaxText/decode.py MaxText/configs/base.yml run_name=$RUN_NAME\
-    steps=100 enable_checkpointing=False metrics_file='metrics.txt'\
+    steps=20 enable_checkpointing=False metrics_file='metrics.txt'\
     base_output_directory=$OUTPUT_PATH
 
 python3 end_to_end/eval_assert.py metrics.txt $NUM_TOKEN_THRESHOLD num_tokens metrics_average

--- a/end_to_end/test_decode_v4_8_one_slice.sh
+++ b/end_to_end/test_decode_v4_8_one_slice.sh
@@ -3,20 +3,21 @@ set -e
 
 NUM_TOKEN_THRESHOLD=${1}
 OUTPUT_PATH=${2}
+DATASET_PATH=${3}
 # Run name is optional 3rd input - our daily XLML tests will use one.
 
 
-if [ -z ${3} ]
+if [ -z ${4} ]
 then 
     RUN_NAME=${USER}_$(date +%Y-%m-%d-%H-%M-%S)
 else
-    RUN_NAME=${3}_$(date +%Y-%m-%d-%H)
+    RUN_NAME=${4}_$(date +%Y-%m-%d-%H)
 fi
 
 #Setup and Train
 bash setup.sh
 python3 MaxText/decode.py MaxText/configs/base.yml run_name=$RUN_NAME\
-    steps=20 enable_checkpointing=False metrics_file='metrics.txt'\
-    base_output_directory=$OUTPUT_PATH
+    steps=50 enable_checkpointing=False metrics_file='metrics.txt'\
+    base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH
 
 python3 end_to_end/eval_assert.py metrics.txt $NUM_TOKEN_THRESHOLD num_tokens metrics_average

--- a/end_to_end/test_decode_v4_8_one_slice.sh
+++ b/end_to_end/test_decode_v4_8_one_slice.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+USER=${1}
+NUM_TOKEN_THRESHOLD=${2}
+OUTPUT_PATH=${3}
+DATASET_PATH=${4}
+# Run name is optional 5th input - our daily XLML tests will use one.
+
+
+if [ -z ${5} ]
+then 
+    RUN_NAME=${USER}_$(date +%Y-%m-%d-%H-%M-%S)
+else
+    RUN_NAME=${5}_$(date +%Y-%m-%d-%H)
+fi
+
+#Setup and Train
+bash setup.sh
+python3 MaxText/decode.py MaxText/configs/base.yml run_name=$RUN_NAME\
+    steps=100 enable_checkpointing=False metrics_file='metrics.txt'\
+    base_output_directory=$OUTPUT_PATH
+
+python3 end_to_end/eval_assert.py metrics.txt $NUM_TOKEN_THRESHOLD num_tokens metrics_average

--- a/end_to_end/test_tflops_v4_16_one_slice.sh
+++ b/end_to_end/test_tflops_v4_16_one_slice.sh
@@ -21,4 +21,4 @@ python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
     enable_checkpointing=False metrics_file='metrics.txt' base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH
 
-python3 end_to_end/eval_assert.py metrics.txt $TFLOP_THRESHOLD perf/per_device_tflops_per_sec performance
+python3 end_to_end/eval_assert.py metrics.txt $TFLOP_THRESHOLD perf/per_device_tflops_per_sec metrics_average

--- a/end_to_end/test_tflops_v4_16_two_slice.sh
+++ b/end_to_end/test_tflops_v4_16_two_slice.sh
@@ -20,4 +20,4 @@ python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
     steps=150 reuse_example_batch=1 remat_policy='full' dcn_data_parallelism=2 ici_fsdp_parallelism=8\
     enable_checkpointing=False metrics_file='metrics.txt' base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH
 
-python3 end_to_end/eval_assert.py metrics.txt $TFLOP_THRESHOLD perf/per_device_tflops_per_sec performance
+python3 end_to_end/eval_assert.py metrics.txt $TFLOP_THRESHOLD perf/per_device_tflops_per_sec metrics_average

--- a/end_to_end/test_tflops_v4_8_one_slice.sh
+++ b/end_to_end/test_tflops_v4_8_one_slice.sh
@@ -17,7 +17,7 @@ fi
 #Setup and Train
 bash setup.sh
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
-    steps=15 reuse_example_batch=1 remat_policy='full' enable_checkpointing=False metrics_file='metrics.txt'\
+    steps=50 reuse_example_batch=1 remat_policy='full' enable_checkpointing=False metrics_file='metrics.txt'\
     base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH
 
 python3 end_to_end/eval_assert.py metrics.txt $TFLOP_THRESHOLD perf/per_device_tflops_per_sec metrics_average

--- a/end_to_end/test_tflops_v4_8_one_slice.sh
+++ b/end_to_end/test_tflops_v4_8_one_slice.sh
@@ -17,7 +17,7 @@ fi
 #Setup and Train
 bash setup.sh
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
-    steps=150 reuse_example_batch=1 remat_policy='full' enable_checkpointing=False metrics_file='metrics.txt'\
+    steps=15 reuse_example_batch=1 remat_policy='full' enable_checkpointing=False metrics_file='metrics.txt'\
     base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH
 
-python3 end_to_end/eval_assert.py metrics.txt $TFLOP_THRESHOLD perf/per_device_tflops_per_sec performance
+python3 end_to_end/eval_assert.py metrics.txt $TFLOP_THRESHOLD perf/per_device_tflops_per_sec metrics_average


### PR DESCRIPTION
XLML test for decoder.py, which tests that decode.py works via counting number of decoded tokens

Also: 
* Fixes decoder.py by removing the config.use_pjrt
* Refactors write_metrics_locally to max_utils so it can be shared by both train.py and decoder.py
* Rename eval_assert.test_flops to eval_assert.assert_metric_average to indicate it be used more generally such as this test

