### PR TITLE
Update import for `partition_spec` and `Mesh`

### DIFF
--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -38,8 +38,8 @@ import jax
 import jax.numpy as jnp
 from jax import random
 from jax.experimental.pjit import pjit
-from jax.experimental.pjit import PartitionSpec as P
-from jax.experimental.maps import Mesh
+from jax._src.partition_spec import PartitionSpec as P
+from jax._src.mesh import Mesh
 
 from jax.experimental.compilation_cache import compilation_cache as cc
 

--- a/MaxText/input_pipeline.py
+++ b/MaxText/input_pipeline.py
@@ -24,7 +24,7 @@ import ml_collections
 import tensorflow as tf
 import tensorflow_datasets as tfds
 import jax
-from jax.experimental.pjit import PartitionSpec as P
+from jax._src.partition_spec import PartitionSpec as P
 
 import tokenizer
 import multihost_dataloading

--- a/MaxText/multihost_dataloading.py
+++ b/MaxText/multihost_dataloading.py
@@ -30,8 +30,8 @@ import time
 import numpy as np
 
 import jax
-from jax.experimental import PartitionSpec
-from jax.experimental.maps import Mesh
+from jax._src.partition_spec import PartitionSpec
+from jax._src.mesh import Mesh
 
 import max_logging
 

--- a/MaxText/tests/input_pipeline_test.py
+++ b/MaxText/tests/input_pipeline_test.py
@@ -18,7 +18,7 @@
 import os
 import sys
 import jax
-from jax.experimental.maps import Mesh
+from jax._src.mesh import Mesh
 from jax.experimental import mesh_utils
 
 import unittest

--- a/MaxText/tests/multihost_dataloading_test.py
+++ b/MaxText/tests/multihost_dataloading_test.py
@@ -19,7 +19,7 @@ import os
 import sys
 import numpy as np
 import jax
-from jax.experimental.maps import Mesh
+from jax._src.mesh import Mesh
 from jax.experimental import mesh_utils
 from jax.experimental import PartitionSpec
 

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -43,8 +43,8 @@ import checkpointing
 import jax.numpy as jnp
 from jax import random
 from jax.experimental.pjit import pjit
-from jax.experimental.pjit import PartitionSpec as P
-from jax.experimental.maps import Mesh
+from jax._src.partition_spec import PartitionSpec as P
+from jax._src.mesh import Mesh
 
 from jax.experimental.compilation_cache import compilation_cache as cc
 

--- a/pedagogical_examples/shardings.py
+++ b/pedagogical_examples/shardings.py
@@ -19,7 +19,8 @@
 '''This script is used to measure the performance of different sharding schemes on TPU.'''
 
 import jax
-from jax.experimental.pjit import PartitionSpec, pjit
+from jax._src.partition_spec import PartitionSpec
+from jax.experimental.pjit import pjit
 from jax.experimental import maps
 from jax.experimental import mesh_utils
 from jax.experimental.compilation_cache import compilation_cache as cc


### PR DESCRIPTION
Update import since `partition_spec` and `Mesh` is no longer in `experimental` folder.