### PR TITLE
Delete the QR using --force in multihost_job

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ either be a TPUVM or not, but it cannot be one of the workers. If your runner ma
     ```
     Create a multislice environment of nodes using create queued resources
     ```
-    gcloud alpha compute tpus queued-resources create $QR_ID --accelerator-type=v4-8 --runtime-version=tpu-vm-v4-base --node-count=$NODE_COUNT --node-prefix=$TPU_PREFIX  --reserved
+    gcloud alpha compute tpus queued-resources create $QR_ID --accelerator-type=v4-8 --runtime-version=tpu-ubuntu2204-base --node-count=$NODE_COUNT --node-prefix=$TPU_PREFIX  --reserved
     ```
     We target the `reserved` pool above, but you may instead target the `on-demand` pool by omitting this flag,
     or target pre-emptible capacity with the `--best-effort` flag, which may be necessary if your reservation is full.

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -161,7 +161,7 @@ source venv/bin/activate
 (({download_from_gcs(zip_gcs_path)}
 tar xzf {zip_name}
 {args.COMMAND}) 2>&1) >> {log_name}
-{echo_finish_status_str()} >> {log_name}
+(echo '{finish_status_str()}') >> {log_name}
 gsutil cp {log_name} "{bucket_path}/"
 sleep 600
 (({create_kill_command_str()}) 2>&1 ) >> {log_name}"""
@@ -183,9 +183,9 @@ PROJECT=$(grep '^CONSUMER_PROJECT_ID' /tmp/tpu-env | cut -d "'" -f 2)"""
     slice_assignment = """SLICE_ID=$(grep '^MEGASCALE_SLICE_ID' /tmp/tpu-env | cut -d "'" -f 2)"""
   return env_str + "\n" + slice_assignment
 
-def echo_finish_status_str():
+def finish_status_str():
   # pylint: disable=line-too-long
-  return """echo "multihost_job finished main command on slice $SLICE_ID worker $WORKER_ID at $(date "+%Y-%m-%d %H:%M:%S") UTC with exit status $?."
+  return """multihost_job finished main command on slice $SLICE_ID worker $WORKER_ID at $(date "+%Y-%m-%d %H:%M:%S") UTC with exit status $?.
 This worker will immediately send its logs to GCS, then wait 10 minutes before tearing down to allow other workers to gracefully tear down."""
 
 def create_kill_command_str():

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -187,9 +187,11 @@ PROJECT=$(grep '^CONSUMER_PROJECT_ID' /tmp/tpu-env | cut -d "'" -f 2)"""
   return env_str + "\n" + slice_assignment
 
 def echo_finish_status_str():
+  # pylint: disable=line-too-long
   return """echo "multihost_job finished main command on slice $SLICE_ID worker $WORKER_ID at $(date "+%Y-%m-%d %H:%M:%S") UTC with exit status $?" """
 
 def create_kill_command_str():
+  # pylint: disable=line-too-long
   return f"""gcloud alpha compute tpus queued-resources delete {args.RUN_NAME} --force --quiet --project={args.PROJECT} --zone={args.ZONE}"""
 
 def download_from_gcs(zip_gcs_path):

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -185,7 +185,8 @@ PROJECT=$(grep '^CONSUMER_PROJECT_ID' /tmp/tpu-env | cut -d "'" -f 2)"""
 
 def echo_finish_status_str():
   # pylint: disable=line-too-long
-  return """echo "multihost_job finished main command on slice $SLICE_ID worker $WORKER_ID at $(date "+%Y-%m-%d %H:%M:%S") UTC with exit status $?" """
+  return """echo "multihost_job finished main command on slice $SLICE_ID worker $WORKER_ID at $(date "+%Y-%m-%d %H:%M:%S") UTC with exit status $?."
+This worker will immediately send its logs to GCS, then wait 10 minutes before tearing down to allow other workers to gracefully tear down."""
 
 def create_kill_command_str():
   # pylint: disable=line-too-long

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -70,8 +70,6 @@ parser.add_argument('--PROJECT', type=str, default=None,
                     help='GCE project name, defaults to gcloud config project')
 parser.add_argument('--ZONE', type=str, default=None,
                     help='GCE zone, e.g. us-central2-b, defaults to gcloud config compute/zone')
-parser.add_argument('--ENDPOINT', type=str, default='tpu.googleapis.com',
-                    help='The endpoint for google API requests.')
 parser.add_argument('--RUN_NAME', type=str, default=None,
                     help='Run name used for temporary files, defaults to timestamp.')
 parser.add_argument('--CQR_EXTRA_ARGS', type=str, default=None,
@@ -109,7 +107,6 @@ def print_flags():
   print(f"Script dir          (--SCRIPT_DIR)      = {args.SCRIPT_DIR}")
   print(f"Bucket name         (--BUCKET_NAME)     = {args.BUCKET_NAME}")
   print(f"Bucket dir          (--BUCKET_DIR)      = {args.BUCKET_DIR}")
-  print(f"Endpoint            (--ENDPOINT)        = {args.ENDPOINT}")
   print(f"Run name            (--RUN_NAME)        = {args.RUN_NAME}")
   print(f"Extra CQR args      (--CQR_EXTRA_ARGS)  = {args.CQR_EXTRA_ARGS}")
   print(f"Command to run      (--COMMAND)         = {args.COMMAND}\n")

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -163,7 +163,7 @@ tar xzf {zip_name}
 {args.COMMAND}) 2>&1) >> {log_name}
 {echo_finish_status_str()} >> {log_name}
 gsutil cp {log_name} "{bucket_path}/"
-sleep 10
+sleep 600
 (({create_kill_command_str()}) 2>&1 ) >> {log_name}"""
 
   with open(startup_script_file, "w", encoding="utf-8") as f:

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -161,7 +161,7 @@ source venv/bin/activate
 (({download_from_gcs(zip_gcs_path)}
 tar xzf {zip_name}
 {args.COMMAND}) 2>&1) >> {log_name}
-(echo '{finish_status_str()}') >> {log_name}
+(echo "{finish_status_str()}") >> {log_name}
 gsutil cp {log_name} "{bucket_path}/"
 sleep 600
 (({create_kill_command_str()}) 2>&1 ) >> {log_name}"""

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -187,10 +187,10 @@ PROJECT=$(grep '^CONSUMER_PROJECT_ID' /tmp/tpu-env | cut -d "'" -f 2)"""
   return env_str + "\n" + slice_assignment
 
 def echo_finish_status_str():
-  return """echo "multihost_job finished main command on slice $SLICE_ID worker $WORKER_ID at $(date "+%Y-%m-%d %H:%M:%S") with exit status $?" """
+  return """echo "multihost_job finished main command on slice $SLICE_ID worker $WORKER_ID at $(date "+%Y-%m-%d %H:%M:%S") UTC with exit status $?" """
 
 def create_kill_command_str():
-  return f"""gcloud alpha compute tpus queued-resources delete {args.RUN_NAME} --force --quiet --async --project={args.PROJECT} --zone={args.ZONE}"""
+  return f"""gcloud alpha compute tpus queued-resources delete {args.RUN_NAME} --force --quiet --project={args.PROJECT} --zone={args.ZONE}"""
 
 def download_from_gcs(zip_gcs_path):
   return f"""


### PR DESCRIPTION
* Use gcloud delete qr --force to delete TPUs and QR at end of command
* Change default runtime-version to tpu-ubuntu2204-base, which has a recent cloud SDK version (the --force flag was only recently added), is actively maintained/updated, and is the version we generally recommend for cloud users. 
* Remove endpoint input (it was unusable due to the recent curl -> gcloud CQR change). It will take some effort to add back, and isn't very valuable at the moment.