### PR TITLE
Add configuration to collect stack traces

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -119,5 +119,5 @@ adam_eps_root: 0. # A small constant applied to denominator inside the square ro
 
 # Stack trace parameters
 collect_stack_trace: True
-stack_trace_to_cloud: False  # display stack trace on console
-stack_trace_interval_seconds: 600  # 10 minutes
+stack_trace_to_cloud: False  # Uploads to cloud logging if True, else to the console if False.
+stack_trace_interval_seconds: 600  # Stack trace collection frequency in seconds.

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -116,3 +116,8 @@ adam_b1: 0.9 # Exponential decay rate to track the first moment of past gradient
 adam_b2: 0.95 # Exponential decay rate to track the second moment of past gradients.
 adam_eps: 1.e-8 # A small constant applied to denominator outside of the square root.
 adam_eps_root: 0. # A small constant applied to denominator inside the square root.
+
+# Stack trace parameters
+collect_stack_trace: True
+stack_trace_to_cloud: False  # display stack trace on console
+stack_trace_interval_seconds: 600  # 10 minutes

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -48,6 +48,11 @@ from jax._src.mesh import Mesh
 
 from jax.experimental.compilation_cache import compilation_cache as cc
 
+from cloud_tpu_diagnostics import diagnostic
+from cloud_tpu_diagnostics.configuration import debug_configuration
+from cloud_tpu_diagnostics.configuration import diagnostic_configuration
+from cloud_tpu_diagnostics.configuration import stack_trace_configuration
+
 import max_logging
 
 cc.initialize_cache(os.path.expanduser("~/jax_cache"))
@@ -337,7 +342,14 @@ def train_loop(config, state=None):
 def main(argv: Sequence[str]) -> None:
   pyconfig.initialize(argv)
   os.environ["TFDS_DATA_DIR"] = pyconfig.config.dataset_path
-  train_loop(pyconfig.config)
+  debug_config = debug_configuration.DebugConfig(
+    stack_trace_config = stack_trace_configuration.StackTraceConfig(
+      collect_stack_trace = pyconfig.config.collect_stack_trace,
+      stack_trace_to_cloud = pyconfig.config.stack_trace_to_cloud,
+      stack_trace_interval_seconds = pyconfig.config.stack_trace_interval_seconds))
+  diagnostic_config = diagnostic_configuration.DiagnosticConfig(debug_config)
+  with diagnostic.diagnose(diagnostic_config):
+    train_loop(pyconfig.config)
 
 
 if __name__ == "__main__":

--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ bash download_dataset.sh {GCS_PROJECT} {GCS_BUCKET_NAME}
 
 To run maxtext the TPUVMs must have permission to read the gcs bucket. These permissions are granted by service account roles, such as the `STORAGE ADMIN` role. 
 
+## Getting Started: Configure Diagnostic Settings
+Here is the related PyPI package: https://pypi.org/project/cloud-tpu-diagnostics.
+### Debugging
+The following configurations will help to debug a fault or when a program is stuck or hung somewhere by collecting stack traces. Change the parameter values accordingly in `MaxText/configs/base.yml`:
+1. Set `collect_stack_trace: True` to enable collection of stack traces on faults or when the program is hung. To disable this, set `collect_stack_trace: False`.
+2. Set `stack_trace_to_cloud: False` to display stack traces on console. `stack_trace_to_cloud: True` will create a temporary file in `/tmp/debugging` in the TPUs to store the stack traces. There is an agent running on TPU VMs that will periodically upload the traces from the temporary directory to cloud logging in the gcp project.
+3. `stack_trace_interval_seconds` signifies the duration in seconds between each stack trace collection event. Setting `stack_trace_interval_seconds: 600` will collect the stack traces every 600 seconds (10 minutes).
+
 ## Getting Started: Local Development
 
 Local development is the faster and most convenient way to run MaxText. However, it doesn't scale to multiple hosts.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,11 @@ Here is the related PyPI package: https://pypi.org/project/cloud-tpu-diagnostics
 ### Debugging
 The following configurations will help to debug a fault or when a program is stuck or hung somewhere by collecting stack traces. Change the parameter values accordingly in `MaxText/configs/base.yml`:
 1. Set `collect_stack_trace: True` to enable collection of stack traces on faults or when the program is hung. To disable this, set `collect_stack_trace: False`.
-2. Set `stack_trace_to_cloud: False` to display stack traces on console. `stack_trace_to_cloud: True` will create a temporary file in `/tmp/debugging` in the TPUs to store the stack traces. There is an agent running on TPU VMs that will periodically upload the traces from the temporary directory to cloud logging in the gcp project.
+2. Set `stack_trace_to_cloud: False` to display stack traces on console. `stack_trace_to_cloud: True` will create a temporary file in `/tmp/debugging` in the TPUs to store the stack traces. There is an agent running on TPU VMs that will periodically upload the traces from the temporary directory to cloud logging in the gcp project. You can view the traces in Logs Explorer on Cloud Logging using the following query:
+```
+logName="projects/<project_name>/logs/tpu.googleapis.com%2Fruntime_monitor"
+jsonPayload.verb="stacktraceanalyzer"
+```
 3. `stack_trace_interval_seconds` signifies the duration in seconds between each stack trace collection event. Setting `stack_trace_interval_seconds: 600` will collect the stack traces every 600 seconds (10 minutes).
 
 ## Getting Started: Local Development

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 orbax-checkpoint
 absl-py
 argparse
+cloud-tpu-diagnostics
 datetime
 google-cloud-storage
 flax

--- a/setup.sh
+++ b/setup.sh
@@ -134,3 +134,6 @@ fi
 
 # Install dependencies from requirements.txt
 cd $run_name_folder_path && pip3 install -r requirements.txt
+
+# Install cloud-tpu-diagnostics
+pip3 install cloud-tpu-diagnostics

--- a/setup.sh
+++ b/setup.sh
@@ -134,6 +134,3 @@ fi
 
 # Install dependencies from requirements.txt
 cd $run_name_folder_path && pip3 install -r requirements.txt
-
-# Install cloud-tpu-diagnostics
-pip3 install cloud-tpu-diagnostics


### PR DESCRIPTION
This PR is to add the configuration to collect python stack traces when a fault such as Segmentation fault, Floating-point exception, Illegal operation exception occurs in the program. Additionally, it will also periodically collect stack traces to help debug when a program running on Cloud TPU is stuck or hung somewhere.

PyPI package: https://pypi.org/project/cloud-tpu-diagnostics/