### PR TITLE
Unsetting GCS Bucket paths by default

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -44,7 +44,7 @@ param_scan_axis: 1
 record_internal_nn_metrics: 0
 
 # Output directory
-base_output_directory: "gs://max-experiments/"
+base_output_directory: ""
 
 # Parallelism
 mesh_axes: ['data', 'fsdp', 'tensor']
@@ -73,7 +73,7 @@ ici_tensor_parallelism: 1
 
 # Dataset
 # Replace with your path given as argument in download_dataset.sh
-dataset_path: "gs://maxtext-dataset/"
+dataset_path: ""
 vocab_size: 32_768 # powers of 2 for sharding
 vocab_relative_path: "vocabs"  # Assumes we're allowed
 dataset_name: 'c4/en:3.0.1'

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -89,7 +89,7 @@ class _HyperParameters():
     base_output_directory = raw_keys["base_output_directory"]
     assert base_output_directory, "Erroring out, need a real base_output_directory"
     assert raw_keys['dataset_path'], "Erroring out, need a real dataset_path.\n\
-      See instructions for dowloading the c4 dataset here:\n\
+      See instructions for downloading the c4 dataset here:\n\
       https://github.com/google/maxtext/blob/main/README.md#getting-started-download-dataset-and-configure.\n"
     raw_keys["tensorboard_dir"] = os.path.join(base_output_directory, run_name, "tensorboard", "")
     raw_keys["checkpoint_dir"] = os.path.join(base_output_directory, run_name, "checkpoints", "")

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -87,6 +87,8 @@ class _HyperParameters():
     run_name = raw_keys["run_name"]
     assert run_name, "Erroring out, need a real run_name"
     base_output_directory = raw_keys["base_output_directory"]
+    assert base_output_directory, "Erroring out, need a real base_output_directory"
+    assert raw_keys['dataset_path'], "Erroring out, need a real dataset_path"
     raw_keys["tensorboard_dir"] = os.path.join(base_output_directory, run_name, "tensorboard", "")
     raw_keys["checkpoint_dir"] = os.path.join(base_output_directory, run_name, "checkpoints", "")
     raw_keys["logical_axis_rules"] = _lists_to_tuples(raw_keys["logical_axis_rules"])

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -90,7 +90,7 @@ class _HyperParameters():
     assert base_output_directory, "Erroring out, need a real base_output_directory"
     assert raw_keys['dataset_path'], "Erroring out, need a real dataset_path.\n\
       See instructions for dowloading the c4 dataset here:\n\
-        https://github.com/google/maxtext/blob/main/README.md#getting-started-download-dataset-and-configure."
+      https://github.com/google/maxtext/blob/main/README.md#getting-started-download-dataset-and-configure.\n"
     raw_keys["tensorboard_dir"] = os.path.join(base_output_directory, run_name, "tensorboard", "")
     raw_keys["checkpoint_dir"] = os.path.join(base_output_directory, run_name, "checkpoints", "")
     raw_keys["logical_axis_rules"] = _lists_to_tuples(raw_keys["logical_axis_rules"])

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -88,7 +88,9 @@ class _HyperParameters():
     assert run_name, "Erroring out, need a real run_name"
     base_output_directory = raw_keys["base_output_directory"]
     assert base_output_directory, "Erroring out, need a real base_output_directory"
-    assert raw_keys['dataset_path'], "Erroring out, need a real dataset_path"
+    assert raw_keys['dataset_path'], "Erroring out, need a real dataset_path.\n\
+      See instructions for dowloading the c4 dataset here:\n\
+        https://github.com/google/maxtext/blob/main/README.md#getting-started-download-dataset-and-configure."
     raw_keys["tensorboard_dir"] = os.path.join(base_output_directory, run_name, "tensorboard", "")
     raw_keys["checkpoint_dir"] = os.path.join(base_output_directory, run_name, "checkpoints", "")
     raw_keys["logical_axis_rules"] = _lists_to_tuples(raw_keys["logical_axis_rules"])

--- a/MaxText/tests/input_pipeline_test.py
+++ b/MaxText/tests/input_pipeline_test.py
@@ -28,7 +28,6 @@ import pyconfig
 import input_pipeline
 
 # By default, XLA presents all the CPU cores as one device. This flag splits up cores in 2 CPU devices.
-os.environ["TFDS_DATA_DIR"] = "gs://maxtext-dataset/"
 os.environ["XLA_FLAGS"] = '--xla_force_host_platform_device_count=2'
 jax.config.update('jax_platform_name', 'cpu')
 
@@ -40,6 +39,7 @@ class InputPipelineTest(unittest.TestCase):
     pyconfig.initialize(sys.argv + ['configs/base.yml'], per_device_batch_size=1, run_name='test', mesh_axes = ['data'],
                         logical_axis_rules = [['batch', 'data']],
                         data_sharding = ['data'])
+    os.environ["TFDS_DATA_DIR"] = pyconfig.config.dataset_path
     self.config = pyconfig.config
     self.read_config = tfds.ReadConfig()
     self.read_config.add_tfds_id = True

--- a/MaxText/tests/multihost_dataloading_test.py
+++ b/MaxText/tests/multihost_dataloading_test.py
@@ -39,7 +39,9 @@ class MultihostDataloadingTest(unittest.TestCase):
     batch_size = 2
     pyconfig.initialize(sys.argv + ['configs/base.yml'], per_device_batch_size=1, run_name='test', mesh_axes = ['data'],
                         logical_axis_rules = [['batch', 'data']],
-                        data_sharding = ['data'])
+                        data_sharding = ['data'],
+                        base_output_directory = "gs://max-experiments",
+                        dataset_path = "gs://maxtext-dataset")
     config = pyconfig.config
     global_data_shape = PartitionSpec(batch_size, config.max_target_length)
     data_sharding = ('data',)

--- a/MaxText/tests/multihost_dataloading_test.py
+++ b/MaxText/tests/multihost_dataloading_test.py
@@ -40,8 +40,8 @@ class MultihostDataloadingTest(unittest.TestCase):
     pyconfig.initialize(sys.argv + ['configs/base.yml'], per_device_batch_size=1, run_name='test', mesh_axes = ['data'],
                         logical_axis_rules = [['batch', 'data']],
                         data_sharding = ['data'],
-                        base_output_directory = "gs://max-experiments",
-                        dataset_path = "gs://maxtext-dataset")
+                        base_output_directory = "gs://max-experiments/",
+                        dataset_path = "gs://maxtext-dataset/")
     config = pyconfig.config
     global_data_shape = PartitionSpec(batch_size, config.max_target_length)
     data_sharding = ('data',)

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ either be a TPUVM or not, but it cannot be one of the workers. If your runner ma
     RUN_NAME=${USER}_$(date +%Y-%m-%d-%H-%M-%S) # You may set this to any unique name for a fresh run.
     ```
     ```
-    python3 multihost_runner.py --TPU_PREFIX=$TPU_PREFIX --COMMAND="python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME base_output_directory=$OUTPUT_DIR dataset_path=$DATASET_PATH"
+    python3 multihost_runner.py --TPU_PREFIX=$TPU_PREFIX --COMMAND="python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME"
     ```
     If you are running the `multihost_runner.py` script from a TPUVM, you will need to set `--INTERNAL_IP=true`.
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You need to run these steps once per project prior to any local development or c
 ```
 bash download_dataset.sh {GCS_PROJECT} {GCS_BUCKET_NAME}
 ```
-3. Change config values for `base_output_directory` and `dataset_path` in `configs/base.yml`. `vocab_relative_path` is relative to `base_output_directory` for loading the tokenizer. MaxText assumes these GCS buckets are created in the same project and that it has permissions to read and write from them. We also recommend reviewing the configurable options in `configs/base.yml`, for instance you may change the `steps` or `logging_period` by either modifying `configs/base.yml` or by passing in `steps` and `logging_period` as additional args to the `train.py` call.
+3. Input config values for `base_output_directory` and `dataset_path` in `configs/base.yml`. `vocab_relative_path` is relative to `base_output_directory` for loading the tokenizer. MaxText assumes these GCS buckets are created in the same project and that it has permissions to read and write from them. We also recommend reviewing the configurable options in `configs/base.yml`, for instance you may change the `steps` or `logging_period` by either modifying `configs/base.yml` or by passing in `steps` and `logging_period` as additional args to the `train.py` call.
 
 To run maxtext the TPUVMs must have permission to read the gcs bucket. These permissions are granted by service account roles, such as the `STORAGE ADMIN` role. 
 
@@ -150,7 +150,7 @@ either be a TPUVM or not, but it cannot be one of the workers. If your runner ma
     RUN_NAME=${USER}_$(date +%Y-%m-%d-%H-%M-%S) # You may set this to any unique name for a fresh run.
     ```
     ```
-    python3 multihost_runner.py --TPU_PREFIX=$TPU_PREFIX --COMMAND="python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME dcn_data_parallelism=$NODE_COUNT"
+    python3 multihost_runner.py --TPU_PREFIX=$TPU_PREFIX --COMMAND="python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME base_output_directory=$OUTPUT_DIR dataset_path=$DATASET_PATH"
     ```
     If you are running the `multihost_runner.py` script from a TPUVM, you will need to set `--INTERNAL_IP=true`.
 
@@ -209,7 +209,7 @@ either be a TPUVM or not. If your runner machine is a TPUVM, it needs service ac
     ```
     ```
     RUN_NAME=${USER}_$(date +%Y-%m-%d-%H-%M-%S) # You may set this to any unique name for a fresh run.
-    python3 multihost_job.py --NUM_SLICES=$NODE_COUNT --RUN_NAME=$RUN_NAME --BUCKET_NAME=$BUCKET_NAME --CQR_EXTRA_ARGS="--reserved" --COMMAND="bash setup.sh && python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME dcn_data_parallelism=$NODE_COUNT"
+    python3 multihost_job.py --NUM_SLICES=$NODE_COUNT --RUN_NAME=$RUN_NAME --BUCKET_NAME=$BUCKET_NAME --CQR_EXTRA_ARGS="--reserved" --COMMAND="bash setup.sh && python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME"
     ```
 
     We tell `multihost_job` to target the `reserved` pool by  by including `--reserved` as extra arguments to the CQR request, but you may instead target the `on-demand` pool by removing the `--CQR_EXTRA_ARGS` flag (on-demand is default), or the pre-emptible pool with `--CQR_EXTRA_ARGS="--best-effort"`, which may be necessary if your reservation is full.


### PR DESCRIPTION
* Unset GCS Bucket paths in base.yml file and additional checks to make sure it is not empty before training
* Removed references to setting dcn parallelism value in README
* Changed hardcoded reference to dataset_path to use config value
* Edited multihost_dataloading_test.py to have gcs bucket params