### PR TITLE
Add collect_stack_trace flag to checkpointing tests

### DIFF
--- a/end_to_end/test_checkpointing.sh
+++ b/end_to_end/test_checkpointing.sh
@@ -4,13 +4,15 @@ set -e
 RUN_NAME=${1}_$(date +%Y-%m-%d-%H)
 OUTPUT_PATH=${2}
 DATASET_PATH=${3}
-
+COLLECT_STACK_TRACE=${4}
 
 #Train
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME steps=501\
-    metrics_file='saved_metrics.txt' save_period=20 base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH
+    metrics_file='saved_metrics.txt' save_period=20 base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH\
+    collect_stack_trace=$COLLECT_STACK_TRACE
 
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME steps=502\
-    metrics_file='restored_metrics.txt' base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH
+    metrics_file='restored_metrics.txt' base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH\
+    collect_stack_trace=$COLLECT_STACK_TRACE
 
 python3 end_to_end/eval_assert.py metrics.txt 0 learning/loss checkpoint_save_restore


### PR DESCRIPTION
This PR adds collect_stack_trace flag to checkpointing tests to run the tests for both the scenarios :
1) when stack trace collection is enabled, 
2) when stack trace collection is disabled.