### PR TITLE
Disable profiler in 16B and 32B end to end test

### DIFF
--- a/end_to_end/test_tflops_16b_params.sh
+++ b/end_to_end/test_tflops_16b_params.sh
@@ -18,7 +18,7 @@ fi
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
     steps=150 per_device_batch_size=2 enable_checkpointing=false\
-    enable_profiler=true remat_policy=proj base_emb_dim=6144 base_mlp_dim=24576\
+    enable_profiler=false remat_policy=proj base_emb_dim=6144 base_mlp_dim=24576\
     base_num_heads=24 base_num_decoder_layers=36 head_dim=256\
     max_target_length=2048 metrics_file='metrics.txt' base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH log_period=150

--- a/end_to_end/test_tflops_32b_params.sh
+++ b/end_to_end/test_tflops_32b_params.sh
@@ -18,7 +18,7 @@ fi
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
     steps=150 per_device_batch_size=1 enable_checkpointing=false\
-    enable_profiler=true remat_policy=proj base_emb_dim=8192 base_mlp_dim=32768\
+    enable_profiler=false remat_policy=proj base_emb_dim=8192 base_mlp_dim=32768\
     base_num_heads=32 base_num_decoder_layers=40 head_dim=256\
     max_target_length=2048 metrics_file='metrics.txt' base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH log_period=150


### PR DESCRIPTION
The test runs for 150 steps which is too many for profiling.