### PR TITLE
add ulimit command

### DIFF
--- a/multihost_job.py
+++ b/multihost_job.py
@@ -158,6 +158,7 @@ cd {args.RUN_NAME}
 {setup_ops_str(args.RUN_NAME, log_name)}
 sudo python3 -m virtualenv venv
 source venv/bin/activate
+ulimit -n 100000
 (({download_from_gcs(zip_gcs_path)}
 tar xzf {zip_name}
 {args.COMMAND}) 2>&1) >> {log_name}


### PR DESCRIPTION
Running as root (as happens in startup-script) only has a ulimit -n limit of 1024, as compared to a limit of 100000 as a user. This causes problems for the MXLA coordinator who has to communicate with every VM. We can simply set this limit to 100000 in the startup script before the MXLA coordinator has to communicate.

Tony tested on 1024 VMs