### PR TITLE
Replace deprecated in_axis_resources with in_shardings in decode.py

### DIFF
--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -164,10 +164,10 @@ def decode_loop(config, state=None):
 
   p_predict_step = pjit(
       functools.partial(predict_step, model=model, config=config),
-      in_axis_resources=(P(None, None),
+      in_shardings=(P(None, None),
                         state_mesh_annotations,
                         None),
-      out_axis_resources=None
+      out_shardings=None
   )
 
   # Encode the demo prompt.


### PR DESCRIPTION
Sharding logic changed in jax 0.4.13 ([release notes](https://github.com/google/jax/releases)), which broke decode.py

Changing in_axis_resources to in_shardings fixes the behavior - in_axis_resources is [deprecated](https://jax.readthedocs.io/en/latest/jax.experimental.pjit.html) in favor of the later 

