### PR TITLE
Change meaning of scale to intuitive definition

### DIFF
--- a/MaxText/configs/1xv4-128.sh
+++ b/MaxText/configs/1xv4-128.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"
-python3 MaxText/train.py MaxText/configs/base.yml run_name=2xv4-64 dcn_data_parallelism=1 ici_fsdp_parallelism=64 steps=10 per_device_batch_size=16  enable_profiler=true remat_policy=full scale=3
+python3 MaxText/train.py MaxText/configs/base.yml run_name=1xv4-128 dcn_data_parallelism=1 ici_fsdp_parallelism=64 steps=10 per_device_batch_size=16  enable_profiler=true remat_policy=full base_emb_dim=6144 base_num_heads=24 base_mlp_dim=24576 base_num_decoder_layers=48  
 # TFLOP/s 165, 22B

--- a/MaxText/configs/1xv4-384.sh
+++ b/MaxText/configs/1xv4-384.sh
@@ -14,5 +14,5 @@
 
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"
 RUN_NAME=1x_v4-384_0013
-python3 MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME} enable_profiler=true enable_checkpointing=false steps=10 ici_fsdp_parallelism=192 ici_tensor_parallelism=1 scale=4 base_num_decoder_layers=8 per_device_batch_size=10 remat_policy=full base_emb_dim=3072 base_mlp_dim=12288 learning_rate=1e-8
+python3 MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME} enable_profiler=true enable_checkpointing=false steps=10 ici_fsdp_parallelism=192 ici_tensor_parallelism=1 base_num_decoder_layers=32 per_device_batch_size=10 remat_policy=full base_emb_dim=12288 base_mlp_dim=49152 base_num_heads=32 learning_rate=1e-8
 # achieves 154 TFLOP/s, 52B

--- a/MaxText/configs/2xv4-128.sh
+++ b/MaxText/configs/2xv4-128.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"
-python3 MaxText/train.py MaxText/configs/base.yml run_name=2xv4-64 dcn_data_parallelism=2 ici_fsdp_parallelism=64 steps=10 per_device_batch_size=16  enable_profiler=true remat_policy=full scale=3
+python3 MaxText/train.py MaxText/configs/base.yml run_name=2xv4-128 dcn_data_parallelism=2 ici_fsdp_parallelism=64 steps=10 per_device_batch_size=16  enable_profiler=true remat_policy=full base_emb_dim=6144 base_num_heads=24 base_mlp_dim=24576 base_num_decoder_layers=48
 # 158TFLOP/s, 22B params

--- a/MaxText/configs/2xv4-384.sh
+++ b/MaxText/configs/2xv4-384.sh
@@ -14,5 +14,5 @@
 
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"
 RUN_NAME=2x_v4-384_0012
-python3 MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME} enable_profiler=true enable_checkpointing=false steps=10 dcn_data_parallelism=2 ici_tensor_parallelism=1 base_num_decoder_layers=32 per_device_batch_size=10 remat_policy=full base_emb_dim=12288 base_mlp_dim=49152 base_num_heads=32 learning_rate=1e-8
+python3 MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME} enable_profiler=true enable_checkpointing=false steps=10 dcn_data_parallelism=2 ici_fsdp_parallelism=192 ici_tensor_parallelism=1 base_num_decoder_layers=32 per_device_batch_size=10 remat_policy=full base_emb_dim=12288 base_mlp_dim=49152 base_num_heads=32 learning_rate=1e-8
 # achieves 162 TFLOP/s, 52B

--- a/MaxText/configs/2xv4-384.sh
+++ b/MaxText/configs/2xv4-384.sh
@@ -14,5 +14,5 @@
 
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"
 RUN_NAME=2x_v4-384_0012
-python3 MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME} enable_profiler=true enable_checkpointing=false steps=10 dcn_data_parallelism=2 ici_fsdp_parallelism=192 ici_tensor_parallelism=1 scale=4 base_num_decoder_layers=8 per_device_batch_size=10 remat_policy=full base_emb_dim=3072 base_mlp_dim=12288 learning_rate=1e-8
+python3 MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME} enable_profiler=true enable_checkpointing=false steps=10 dcn_data_parallelism=2 ici_tensor_parallelism=1 base_num_decoder_layers=32 per_device_batch_size=10 remat_policy=full base_emb_dim=12288 base_mlp_dim=49152 base_num_heads=32 learning_rate=1e-8
 # achieves 162 TFLOP/s, 52B

--- a/MaxText/configs/4xv4-128.sh
+++ b/MaxText/configs/4xv4-128.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"
-python3 MaxText/train.py MaxText/configs/base.yml run_name=2xv4-64 dcn_data_parallelism=4 ici_fsdp_parallelism=64 steps=10 per_device_batch_size=16  enable_profiler=true remat_policy=full scale=3
+python3 MaxText/train.py MaxText/configs/base.yml run_name=4xv4-128 dcn_data_parallelism=4 ici_fsdp_parallelism=64 steps=10 per_device_batch_size=16  enable_profiler=true remat_policy=full base_emb_dim=6144 base_num_heads=24 base_mlp_dim=24576 base_num_decoder_layers=48
 # 157 TFLOP/s, 22B

--- a/MaxText/configs/8xv4-128.sh
+++ b/MaxText/configs/8xv4-128.sh
@@ -13,5 +13,5 @@
 # limitations under the License.
 
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"
-python3 MaxText/train.py MaxText/configs/base.yml run_name=8xv4-128 dcn_data_parallelism=8 ici_fsdp_parallelism=64 steps=10 per_device_batch_size=16  enable_profiler=true remat_policy=full scale=3
+python3 MaxText/train.py MaxText/configs/base.yml run_name=8xv4-128 dcn_data_parallelism=8 ici_fsdp_parallelism=64 steps=10 per_device_batch_size=16  enable_profiler=true remat_policy=full base_emb_dim=6144 base_num_heads=24 base_mlp_dim=24576 base_num_decoder_layers=48
 # 146 TFLOP/s, 22B

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -47,7 +47,7 @@ record_internal_nn_metrics: 0
 
 # Output directory
 # Create a GCS bucket, e.g. my-maxtext-outputs and set this to "gs://my-maxtext-outputs/"
-base_output_directory: "" 
+base_output_directory: "gs://maxtext-experiments-multipod/"
 
 # Parallelism
 mesh_axes: ['data', 'fsdp', 'tensor']
@@ -80,7 +80,7 @@ ici_tensor_parallelism: 1
 
 # Dataset
 # Replace with your path given as argument in download_dataset.sh, e.g. "gs://my-maxtext-dataset/"
-dataset_path: ""
+dataset_path: "gs://max-datasets-rogue/"
 vocab_size: 32_768 # powers of 2 for sharding
 vocab_relative_path: "vocabs"  # Assumes we're allowed
 dataset_name: 'c4/en:3.0.1'

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -26,9 +26,9 @@ metrics_file: "" # for testing, local file that stores scalar metrics. If empty,
 # Activation dtypes.
 dtype: "bfloat16"
 use_int8_training: False
-# Scale is rounded down to the nearest power of 2. If you want finer grained control of the model sizes 
+# Global parameter scale needs to be a power of 2. If you want finer grained control of the model sizes 
 # then you should explicitly set base_embed_dim, base_num_heads, base_mlp_dim, base_num_decoder_layers and/or head_dim.
-scale: 1
+global_parameter_scale: 1
 base_emb_dim: 2048
 base_num_heads: 8
 base_mlp_dim: 8192

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -86,7 +86,7 @@ vocab_relative_path: "vocabs"  # Assumes we're allowed
 dataset_name: 'c4/en:3.0.1'
 eval_dataset_name: 'c4/en:3.0.1'
 eval_split: 'validation'
-per_device_batch_size: 32
+per_device_batch_size: 24
 eval_per_device_batch_size: 0
 max_corpus_chars: 10_000_000
 

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -47,7 +47,7 @@ record_internal_nn_metrics: 0
 
 # Output directory
 # Create a GCS bucket, e.g. my-maxtext-outputs and set this to "gs://my-maxtext-outputs/"
-base_output_directory: "gs://maxtext-experiments-multipod/"
+base_output_directory: ""
 
 # Parallelism
 mesh_axes: ['data', 'fsdp', 'tensor']
@@ -80,7 +80,7 @@ ici_tensor_parallelism: 1
 
 # Dataset
 # Replace with your path given as argument in download_dataset.sh, e.g. "gs://my-maxtext-dataset/"
-dataset_path: "gs://max-datasets-rogue/"
+dataset_path: ""
 vocab_size: 32_768 # powers of 2 for sharding
 vocab_relative_path: "vocabs"  # Assumes we're allowed
 dataset_name: 'c4/en:3.0.1'

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -26,11 +26,13 @@ metrics_file: "" # for testing, local file that stores scalar metrics. If empty,
 # Activation dtypes.
 dtype: "bfloat16"
 use_int8_training: False
+# Scale is rounded down to the nearest power of 2. If you want finer grained control of the model sizes 
+# then you should explicitly set base_embed_dim, base_num_heads, base_mlp_dim, base_num_decoder_layers and/or head_dim.
 scale: 1
 base_emb_dim: 2048
-base_num_heads: 8
-base_mlp_dim: 8192
-base_num_decoder_layers: 16
+base_num_heads: 12
+base_mlp_dim: 6144
+base_num_decoder_layers: 20
 head_dim: 256
 # activation functions are .
 mlp_activations: ["relu"]

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -30,8 +30,8 @@ use_int8_training: False
 # then you should explicitly set base_embed_dim, base_num_heads, base_mlp_dim, base_num_decoder_layers and/or head_dim.
 scale: 1
 base_emb_dim: 2048
-base_num_heads: 12
-base_mlp_dim: 6144
+base_num_heads: 8
+base_mlp_dim: 8192
 base_num_decoder_layers: 20
 head_dim: 256
 # activation functions are .

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -17,6 +17,7 @@
 # pylint: disable=missing-module-docstring
 from collections import OrderedDict
 
+import math
 import os
 import sys
 import yaml
@@ -99,6 +100,15 @@ class _HyperParameters():
     raw_keys['num_heads'] = raw_keys['scale'] * raw_keys['base_num_heads']
     raw_keys['mlp_dim'] = raw_keys['scale'] * raw_keys['base_mlp_dim']
     raw_keys['num_decoder_layers'] = raw_keys['scale'] * raw_keys['base_num_decoder_layers']
+
+def get_scales(scale):
+  log_2_scale = math.floor((math.log2(scale)))
+  base_scale, rem = divmod(log_2_scale, 3)
+  emb_scale = base_scale + rem > 0
+  num_head_scale = base_scale + rem > 1
+  mlp_dim_scale = base_scale + rem > 1
+  layer_scale = base_scale
+
 
 
 

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -20,7 +20,6 @@ from collections import OrderedDict
 import math
 import os
 import sys
-import warnings
 import yaml
 
 import jax

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -98,13 +98,13 @@ class _HyperParameters():
     raw_keys["logical_axis_rules"] = _lists_to_tuples(raw_keys["logical_axis_rules"])
     raw_keys["data_sharding"] = _lists_to_tuples(raw_keys["data_sharding"])
 
-    emb_scale, num_head_scale, mlp_dim_scale, layer_scale = get_scales(raw_keys['scale'])
+    emb_scale, num_head_scale, mlp_dim_scale, layer_scale = get_individual_scales(raw_keys['scale'])
     raw_keys['emb_dim'] = emb_scale * raw_keys['base_emb_dim']
     raw_keys['num_heads'] = num_head_scale * raw_keys['base_num_heads']
     raw_keys['mlp_dim'] = mlp_dim_scale * raw_keys['base_mlp_dim']
     raw_keys['num_decoder_layers'] = layer_scale * raw_keys['base_num_decoder_layers']
 
-def get_scales(scale):
+def get_individual_scales(scale):
   '''Choose appropriate scales for individual dimensions based on global scale
   We choose to rotate between doubling:
     embed_dim
@@ -116,8 +116,8 @@ def get_scales(scale):
 
   log_2_scale = math.floor((math.log2(scale)))
   if 2**log_2_scale != scale:
-    scale_warning = ("Scale is rounded down to the nearest power of 2. If you want finer grained control"
-                    "of the model sizes explicitly set embed_dim, num_head, mlp_dim, num_layers or head_dim")
+    scale_warning = ("Scale is rounded down to the nearest power of 2. If you want finer grained control of the model sizes " 
+      "then you should explicitly set base_embed_dim, base_num_heads, base_mlp_dim, base_num_decoder_layers and/or head_dim.")
     warnings.warn(scale_warning, category=Warning)
   base_scale, rem = divmod(log_2_scale, 3)
   base_scale += 1 
@@ -125,11 +125,7 @@ def get_scales(scale):
   num_head_scale = base_scale + int(rem > 1)
   mlp_dim_scale = base_scale + int(rem > 1)
   layer_scale = base_scale
-  print('\n\n\n\n\n\n')
-  print("scales:",emb_scale, num_head_scale, mlp_dim_scale, layer_scale, flush=True)
-  print('\n\n\n\n\n\n')
   return emb_scale, num_head_scale, mlp_dim_scale, layer_scale
-
 
 
 

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -123,7 +123,7 @@ def get_individual_scales(scale):
   base_scale += 1 
   emb_scale = base_scale + int(rem > 0)
   num_head_scale = base_scale + int(rem > 1)
-  mlp_dim_scale = base_scale + int(rem > 1)
+  mlp_dim_scale = num_head_scale
   layer_scale = base_scale
   return emb_scale, num_head_scale, mlp_dim_scale, layer_scale
 

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -116,11 +116,11 @@ def get_individual_scales(scale):
 
   log_2_scale = math.floor((math.log2(scale)))
   if 2**log_2_scale != scale:
-    scale_warning = ("Scale is rounded down to the nearest power of 2. If you want finer grained control of the model sizes " 
-      "then you should explicitly set base_embed_dim, base_num_heads, base_mlp_dim, base_num_decoder_layers and/or head_dim.")
+    scale_warning = ("Scale is rounded down to the nearest power of 2. If you want finer grained control of the model sizes "
+      "then you can explicitly set base_embed_dim, base_num_heads, base_mlp_dim, base_num_decoder_layers and/or head_dim.")
     warnings.warn(scale_warning, category=Warning)
   base_scale, rem = divmod(log_2_scale, 3)
-  base_scale += 1 
+  base_scale += 1
   emb_scale = base_scale + int(rem > 0)
   num_head_scale = base_scale + int(rem > 1)
   mlp_dim_scale = num_head_scale

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -98,7 +98,7 @@ class _HyperParameters():
     raw_keys["logical_axis_rules"] = _lists_to_tuples(raw_keys["logical_axis_rules"])
     raw_keys["data_sharding"] = _lists_to_tuples(raw_keys["data_sharding"])
 
-    emb_scale, num_head_scale, mlp_dim_scale, layer_scale = get_individual_scales(raw_keys['scale'])
+    emb_scale, num_head_scale, mlp_dim_scale, layer_scale = get_individual_scales(raw_keys['global_parameter_scale'])
     raw_keys['emb_dim'] = emb_scale * raw_keys['base_emb_dim']
     raw_keys['num_heads'] = num_head_scale * raw_keys['base_num_heads']
     raw_keys['mlp_dim'] = mlp_dim_scale * raw_keys['base_mlp_dim']
@@ -116,9 +116,8 @@ def get_individual_scales(scale):
 
   log_2_scale = math.floor((math.log2(scale)))
   if 2**log_2_scale != scale:
-    scale_warning = ("Scale is rounded down to the nearest power of 2. If you want finer grained control of the model sizes "
+    raise ValueError("Global parameter scale should be a power of 2. If you want finer grained control of the model sizes "
       "then you can explicitly set base_embed_dim, base_num_heads, base_mlp_dim, base_num_decoder_layers and/or head_dim.")
-    warnings.warn(scale_warning, category=Warning)
   base_scale, rem = divmod(log_2_scale, 3)
   base_scale += 1
   emb_scale = base_scale + int(rem > 0)


### PR DESCRIPTION
Previously scale actually scaled the model roughly cubicly since it affected all dimensions.

With this change scale affects the model roughly linearly (for scale values that are powers of 2). Scale values need to be powers of 2, or a helpful error message is printed

The base config is also changed to be close to 1B params (actually 1B + 65M since there is a 65M linear layer at the end that does not scale the same as the rest of the tensors)

The new base config gets a slight perf boost (161 TFLOPs compared with old 157) on v4-8