### PR TITLE
Bucket name normalize

### DIFF
--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -89,9 +89,12 @@ class _HyperParameters():
     assert run_name, "Erroring out, need a real run_name"
     base_output_directory = raw_keys["base_output_directory"]
     assert base_output_directory, "Erroring out, please set a real base_output_directory"
-    assert raw_keys['dataset_path'], "Erroring out, please set a real dataset_path in configs/base.yml\n\
+    assert len(base_output_directory) > 5 and base_output_directory[0:5]=="gs://", "Erroring out, base_output_directory should start with gs://"
+    dataset_path = raw_keys["dataset_path"]
+    assert dataset_path, "Erroring out, please set a real dataset_path in configs/base.yml\n\
       See instructions for downloading the c4 dataset here:\n\
       https://github.com/google/maxtext/blob/main/README.md#getting-started-download-dataset-and-configure.\n"
+    assert len(dataset_path) > 5 and dataset_path=="gs://", "Erroring out, dataset_path should start with gs://"
     raw_keys["tensorboard_dir"] = os.path.join(base_output_directory, run_name, "tensorboard", "")
     raw_keys["checkpoint_dir"] = os.path.join(base_output_directory, run_name, "checkpoints", "")
     raw_keys["metrics_dir"] = os.path.join(base_output_directory, run_name, "metrics", "")

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -88,13 +88,13 @@ class _HyperParameters():
     run_name = raw_keys["run_name"]
     assert run_name, "Erroring out, need a real run_name"
     base_output_directory = raw_keys["base_output_directory"]
-    assert base_output_directory, "Erroring out, please set a real base_output_directory"
-    assert len(base_output_directory) > 5 and base_output_directory[0:5]=="gs://", "Erroring out, base_output_directory should start with gs://"
+    assert base_output_directory, "please set a real base_output_directory"
+    validate_gcs_bucket_name(base_output_directory, "base_output_directory")
     dataset_path = raw_keys["dataset_path"]
     assert dataset_path, "Erroring out, please set a real dataset_path in configs/base.yml\n\
       See instructions for downloading the c4 dataset here:\n\
       https://github.com/google/maxtext/blob/main/README.md#getting-started-download-dataset-and-configure.\n"
-    assert len(dataset_path) > 5 and dataset_path=="gs://", "Erroring out, dataset_path should start with gs://"
+    validate_gcs_bucket_name(dataset_path, "dataset_path")
     raw_keys["tensorboard_dir"] = os.path.join(base_output_directory, run_name, "tensorboard", "")
     raw_keys["checkpoint_dir"] = os.path.join(base_output_directory, run_name, "checkpoints", "")
     raw_keys["metrics_dir"] = os.path.join(base_output_directory, run_name, "metrics", "")
@@ -106,6 +106,9 @@ class _HyperParameters():
     raw_keys['num_heads'] = num_head_scale * raw_keys['base_num_heads']
     raw_keys['mlp_dim'] = mlp_dim_scale * raw_keys['base_mlp_dim']
     raw_keys['num_decoder_layers'] = layer_scale * raw_keys['base_num_decoder_layers']
+
+def validate_gcs_bucket_name(bucket_name, config_var):
+  assert len(bucket_name) > 5 and bucket_name[0:5]=='gs://', f"Erroring out, {config_var} should start with 'gs://' "
 
 def get_individual_scales(scale):
   '''Choose appropriate scales for individual dimensions based on global scale

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -88,12 +88,8 @@ class _HyperParameters():
     run_name = raw_keys["run_name"]
     assert run_name, "Erroring out, need a real run_name"
     base_output_directory = raw_keys["base_output_directory"]
-    assert base_output_directory, "please set a real base_output_directory"
     validate_gcs_bucket_name(base_output_directory, "base_output_directory")
     dataset_path = raw_keys["dataset_path"]
-    assert dataset_path, "Erroring out, please set a real dataset_path in configs/base.yml\n\
-      See instructions for downloading the c4 dataset here:\n\
-      https://github.com/google/maxtext/blob/main/README.md#getting-started-download-dataset-and-configure.\n"
     validate_gcs_bucket_name(dataset_path, "dataset_path")
     raw_keys["tensorboard_dir"] = os.path.join(base_output_directory, run_name, "tensorboard", "")
     raw_keys["checkpoint_dir"] = os.path.join(base_output_directory, run_name, "checkpoints", "")
@@ -108,6 +104,7 @@ class _HyperParameters():
     raw_keys['num_decoder_layers'] = layer_scale * raw_keys['base_num_decoder_layers']
 
 def validate_gcs_bucket_name(bucket_name, config_var):
+  assert bucket_name, f"Please set {config_var}."
   assert len(bucket_name) > 5 and bucket_name[0:5]=='gs://', f"Erroring out, {config_var} should start with 'gs://' "
 
 def get_individual_scales(scale):

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -78,6 +78,9 @@ parser.add_argument('--CQR_EXTRA_ARGS', type=str, default=None,
 
 args = parser.parse_args()
 
+if len(args.BUCKET_NAME) > 5 and args.BUCKET_NAME[0:5]=="gs://" :
+  raise ValueError("BUCKET_NAME should NOT include gs://, e.g. use my-bucket instead of gs://my-bucket.")
+
 def get_project():
   completed_command = subprocess.run(["gcloud", "config", "get", "project"], check=True, capture_output=True)
   project_outputs = completed_command.stdout.decode().strip().split('\n')

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -99,6 +99,11 @@ def get_run_name():
   now = datetime.now()
   return os.getlogin() + "-" + now.strftime("%Y-%m-%d-%H-%M-%S")
 
+def normalize_gcs_bucket_name():
+  """ Remove the gs:// from bucket_name if passed """
+  if len(args.BUCKET_NAME) > 5 and args.BUCKET_NAME[0:5]=="gs://":
+    args.BUCKET_NAME=args.BUCKET_NAME[5:]
+
 def print_flags():
   """ Print configuration values after defaults have been filled in. """
   print("Running multihost_job with the following configuration:")
@@ -283,6 +288,7 @@ def main() -> None:
     args.ZONE = get_zone()
   if not args.RUN_NAME:
     args.RUN_NAME = get_run_name() # Used for QR name, TPU_PREFIX, logging file, and tmp json file.
+  normalize_gcs_bucket_name()
 
   print_flags()
 

--- a/multihost_job.py
+++ b/multihost_job.py
@@ -78,9 +78,6 @@ parser.add_argument('--CQR_EXTRA_ARGS', type=str, default=None,
 
 args = parser.parse_args()
 
-if len(args.BUCKET_NAME) > 5 and args.BUCKET_NAME[0:5]=="gs://" :
-  raise ValueError("BUCKET_NAME should NOT include gs://, e.g. use my-bucket instead of gs://my-bucket.")
-
 def get_project():
   completed_command = subprocess.run(["gcloud", "config", "get", "project"], check=True, capture_output=True)
   project_outputs = completed_command.stdout.decode().strip().split('\n')
@@ -100,7 +97,7 @@ def get_run_name():
   return os.getlogin() + "-" + now.strftime("%Y-%m-%d-%H-%M-%S")
 
 def normalize_gcs_bucket_name():
-  """ Remove the gs:// from bucket_name if passed """
+  """ Remove the gs:// from bucket_name if passed."""
   if len(args.BUCKET_NAME) > 5 and args.BUCKET_NAME[0:5]=="gs://":
     args.BUCKET_NAME=args.BUCKET_NAME[5:]
 


### PR DESCRIPTION
We choose to normalize the bucket name (so it can include the "gs://" or not in multihost_job since it is clearly a bucket by the variable name, however in maxtext we instead choose to validate and enforce the gs:// since the base_output_directory and dataset_path are not obviously buckets (perhaps they should be renamed, but this validator will quickly instruct users what to do).