### PR TITLE
Retry setup

### DIFF
--- a/setup_with_retries.sh
+++ b/setup_with_retries.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+max_attempts=5
+current_attempt=1
+
+# Loop until setup succeeds or reaches the maximum number of attempts
+while [ $current_attempt -le $max_attempts ]; do
+    echo "Attempt to run setup.sh $current_attempt:"
+    bash setup.sh "$@"
+
+    # Check the exit status of run_setup
+    if [ $? -eq 0 ]; then
+        echo "Success for running setup on attempt $current_attempt!"
+        exit 0
+    else
+        echo "Failed to run setupsetup on attempt $current_attempt"
+        ((current_attempt++))
+        sleep 5  # Short delay before next attempt
+    fi
+done
+
+echo "All attempts on setup failed. Exiting."
+exit 1

--- a/setup_with_retries.sh
+++ b/setup_with_retries.sh
@@ -13,11 +13,11 @@ while [ $current_attempt -le $max_attempts ]; do
         echo "Success for running setup on attempt $current_attempt!"
         exit 0
     else
-        echo "Failed to run setupsetup on attempt $current_attempt"
+        echo "Failed to run setup on attempt $current_attempt."
         ((current_attempt++))
         sleep 5  # Short delay before next attempt
     fi
 done
 
-echo "All attempts on setup failed. Exiting."
+echo "All attempts to run setup failed. Exiting."
 exit 1


### PR DESCRIPTION
Add a script to retry setup.sh

We have seen "HASHES DO NOT MATCH" errors on a large number of hosts. This issue is rare per host (~1%) so can be fixed by a retry. 

We have tried --no-cache-dir and pip cache purge but these do not fix the issue.