### PR TITLE
Add support for per_device_batch_size<1

### DIFF
--- a/MaxText/input_pipeline.py
+++ b/MaxText/input_pipeline.py
@@ -217,11 +217,7 @@ def preprocess_dataset(config: ml_collections.ConfigDict,
       tokenizer.TokenizeOp(sp_tokenizer), num_parallel_calls=AUTOTUNE)
 
   # Set global batch size.
-  if config.per_device_batch_size < 1:
-    # For per_device_batch_size<1, we load the data as if per_device_batch_size=1
-    batch_size = global_mesh.size
-  else:
-    batch_size = max_utils.calculate_raw_input_batch_size(config.per_device_batch_size)
+  batch_size = config.batch_size_to_load
 
   if config.eval_per_device_batch_size > 0:
     eval_batch_size = config.eval_per_device_batch_size * global_mesh.size

--- a/MaxText/input_pipeline.py
+++ b/MaxText/input_pipeline.py
@@ -29,7 +29,6 @@ from jax.sharding import PartitionSpec as P
 import tokenizer
 import multihost_dataloading
 import sequence_packing
-import max_utils
 
 AUTOTUNE = tf.data.experimental.AUTOTUNE
 

--- a/MaxText/input_pipeline.py
+++ b/MaxText/input_pipeline.py
@@ -216,7 +216,11 @@ def preprocess_dataset(config: ml_collections.ConfigDict,
       tokenizer.TokenizeOp(sp_tokenizer), num_parallel_calls=AUTOTUNE)
 
   # Set global batch size.
-  batch_size = config.per_device_batch_size * global_mesh.size
+  if config.per_device_batch_size < 1:
+    batch_size = global_mesh.size
+  else:
+    batch_size = int(config.per_device_batch_size) * global_mesh.size
+
   if config.eval_per_device_batch_size > 0:
     eval_batch_size = config.eval_per_device_batch_size * global_mesh.size
   else:

--- a/MaxText/input_pipeline.py
+++ b/MaxText/input_pipeline.py
@@ -216,12 +216,12 @@ def preprocess_dataset(config: ml_collections.ConfigDict,
       tokenizer.TokenizeOp(sp_tokenizer), num_parallel_calls=AUTOTUNE)
 
   # Set global batch size.
-  batch_size = config.batch_size_to_load
+  global_batch_size_to_load = config.global_batch_size_to_load
 
   if config.eval_per_device_batch_size > 0:
     eval_batch_size = config.eval_per_device_batch_size * global_mesh.size
   else:
-    eval_batch_size = batch_size
+    eval_batch_size = global_batch_size_to_load
 
   def filter_keys(record):
     return {'inputs': record['inputs'], 'targets': record['targets']}
@@ -230,7 +230,7 @@ def preprocess_dataset(config: ml_collections.ConfigDict,
 
   train_iter = preprocessing_pipeline(
       train_ds,
-      batch_size,
+      global_batch_size_to_load,
       global_mesh,
       shuffle=config.enable_data_shuffling,
       num_epochs=None,

--- a/MaxText/input_pipeline.py
+++ b/MaxText/input_pipeline.py
@@ -29,6 +29,7 @@ from jax.sharding import PartitionSpec as P
 import tokenizer
 import multihost_dataloading
 import sequence_packing
+import max_utils
 
 AUTOTUNE = tf.data.experimental.AUTOTUNE
 
@@ -217,9 +218,10 @@ def preprocess_dataset(config: ml_collections.ConfigDict,
 
   # Set global batch size.
   if config.per_device_batch_size < 1:
+    # For per_device_batch_size<1, we load the data as if per_device_batch_size=1
     batch_size = global_mesh.size
   else:
-    batch_size = int(config.per_device_batch_size) * global_mesh.size
+    batch_size = max_utils.calculate_raw_input_batch_size(config.per_device_batch_size)
 
   if config.eval_per_device_batch_size > 0:
     eval_batch_size = config.eval_per_device_batch_size * global_mesh.size

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -168,7 +168,7 @@ def init_train_state(model, tx, config, key):
   Args: model, tx, config, key
   """
   input_shape = (
-      config.batch_size_to_load,
+      config.global_batch_size_to_load,
       config.max_target_length
   )
   model_vars = model.init({'params': key, 'dropout': key, 'aqt': key},

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -167,14 +167,8 @@ def init_train_state(model, tx, config, key):
 
   Args: model, tx, config, key
   """
-  if config.per_device_batch_size < 1:
-    input_shape = (
-        len(jax.devices()),
-        config.max_target_length
-    )
-  else:
-    input_shape = (
-        calculate_raw_input_batch_size(config.per_device_batch_size),
+  input_shape = (
+        config.batch_size_to_load,
         config.max_target_length
     )
   model_vars = model.init({'params': key, 'dropout': key, 'aqt': key},
@@ -233,8 +227,6 @@ def setup_initial_state(model, tx, config, rng, mesh, checkpoint_manager):
   state = unbox_logicallypartioned_trainstate(state)
   return state, state_mesh_annotations
 
-def calculate_raw_input_batch_size(per_device_batch_size):
-  return int(len(jax.devices()) * per_device_batch_size)
 
 
 # Learning Rate Schedule

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -168,9 +168,9 @@ def init_train_state(model, tx, config, key):
   Args: model, tx, config, key
   """
   input_shape = (
-        config.batch_size_to_load,
-        config.max_target_length
-    )
+      config.batch_size_to_load,
+      config.max_target_length
+  )
   model_vars = model.init({'params': key, 'dropout': key, 'aqt': key},
                           jnp.ones(input_shape),
                           jnp.ones(input_shape))
@@ -226,7 +226,6 @@ def setup_initial_state(model, tx, config, rng, mesh, checkpoint_manager):
 
   state = unbox_logicallypartioned_trainstate(state)
   return state, state_mesh_annotations
-
 
 
 # Learning Rate Schedule

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -174,7 +174,7 @@ def init_train_state(model, tx, config, key):
     )
   else:
     input_shape = (
-        int(len(jax.devices()) * config.per_device_batch_size),
+        calculate_raw_input_batch_size(config.per_device_batch_size),
         config.max_target_length
     )
   model_vars = model.init({'params': key, 'dropout': key, 'aqt': key},
@@ -232,6 +232,9 @@ def setup_initial_state(model, tx, config, rng, mesh, checkpoint_manager):
 
   state = unbox_logicallypartioned_trainstate(state)
   return state, state_mesh_annotations
+
+def calculate_raw_input_batch_size(per_device_batch_size):
+  return int(len(jax.devices()) * per_device_batch_size)
 
 
 # Learning Rate Schedule

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -167,10 +167,16 @@ def init_train_state(model, tx, config, key):
 
   Args: model, tx, config, key
   """
-  input_shape = (
-      len(jax.devices()) * config.per_device_batch_size,
-      config.max_target_length
-  )
+  if config.per_device_batch_size < 1:
+    input_shape = (
+        len(jax.devices()),
+        config.max_target_length
+    )
+  else:
+    input_shape = (
+        int(len(jax.devices()) * config.per_device_batch_size),
+        config.max_target_length
+    )
   model_vars = model.init({'params': key, 'dropout': key, 'aqt': key},
                           jnp.ones(input_shape),
                           jnp.ones(input_shape))

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -109,7 +109,7 @@ class _HyperParameters():
     raw_keys['mlp_dim'] = 2**mlp_dim_scale * raw_keys['base_mlp_dim']
     raw_keys['num_decoder_layers'] = 2**layer_scale * raw_keys['base_num_decoder_layers']
 
-    raw_keys['batch_size_to_load'], raw_keys['batch_size_to_train_on'] = calculate_global_batch_sizes(raw_keys['per_device_batch_size'])
+    raw_keys['global_batch_size_to_load'], raw_keys['global_batch_size_to_train_on'] = calculate_global_batch_sizes(raw_keys['per_device_batch_size'])
 
 def validate_gcs_bucket_name(bucket_name, config_var):
   assert bucket_name, f"Please set {config_var}."
@@ -140,12 +140,12 @@ def calculate_global_batch_sizes(per_device_batch_size):
   num_devices = len(jax.devices())
   if per_device_batch_size < 1:
     # For per_device_batch_size<1, we load the data as if per_device_batch_size=1
-    batch_size_to_load = num_devices
+    global_batch_size_to_load = num_devices
   else:
-    batch_size_to_load = int(num_devices * per_device_batch_size)
+    global_batch_size_to_load = int(num_devices * per_device_batch_size)
 
-  batch_size_to_train_on = int(num_devices * per_device_batch_size)
-  return batch_size_to_load, batch_size_to_train_on
+  global_batch_size_to_train_on = int(num_devices * per_device_batch_size)
+  return global_batch_size_to_load, global_batch_size_to_train_on
 
 class HyperParameters(): # pylint: disable=missing-class-docstring
   def __init__(self):

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -109,7 +109,8 @@ class _HyperParameters():
     raw_keys['mlp_dim'] = 2**mlp_dim_scale * raw_keys['base_mlp_dim']
     raw_keys['num_decoder_layers'] = 2**layer_scale * raw_keys['base_num_decoder_layers']
 
-    raw_keys['global_batch_size_to_load'], raw_keys['global_batch_size_to_train_on'] = calculate_global_batch_sizes(raw_keys['per_device_batch_size'])
+    raw_keys['global_batch_size_to_load'], raw_keys['global_batch_size_to_train_on'] = \
+      calculate_global_batch_sizes(raw_keys['per_device_batch_size'])
 
 def validate_gcs_bucket_name(bucket_name, config_var):
   assert bucket_name, f"Please set {config_var}."

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -109,7 +109,7 @@ class _HyperParameters():
     raw_keys['mlp_dim'] = 2**mlp_dim_scale * raw_keys['base_mlp_dim']
     raw_keys['num_decoder_layers'] = 2**layer_scale * raw_keys['base_num_decoder_layers']
 
-    raw_keys['batch_size_to_load'], raw_keys['batch_size_to_train_on'] = get_batch_sizes(raw_keys['per_device_batch_size'])
+    raw_keys['batch_size_to_load'], raw_keys['batch_size_to_train_on'] = calculate_global_batch_sizes(raw_keys['per_device_batch_size'])
 
 def validate_gcs_bucket_name(bucket_name, config_var):
   assert bucket_name, f"Please set {config_var}."
@@ -136,7 +136,7 @@ def get_individual_scales(scale):
   layer_scale = base_scale
   return emb_scale, num_head_scale, mlp_dim_scale, layer_scale
 
-def get_batch_sizes(per_device_batch_size):
+def calculate_global_batch_sizes(per_device_batch_size):
   num_devices = len(jax.devices())
   if per_device_batch_size < 1:
     # For per_device_batch_size<1, we load the data as if per_device_batch_size=1

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -109,6 +109,8 @@ class _HyperParameters():
     raw_keys['mlp_dim'] = 2**mlp_dim_scale * raw_keys['base_mlp_dim']
     raw_keys['num_decoder_layers'] = 2**layer_scale * raw_keys['base_num_decoder_layers']
 
+    raw_keys['batch_size_to_load'], raw_keys['batch_size_to_train_on'] = get_batch_sizes(raw_keys['per_device_batch_size'])
+
 def validate_gcs_bucket_name(bucket_name, config_var):
   assert bucket_name, f"Please set {config_var}."
   assert len(bucket_name) > 5 and bucket_name[0:5]=='gs://', f"Erroring out, {config_var} should start with 'gs://' "
@@ -134,7 +136,16 @@ def get_individual_scales(scale):
   layer_scale = base_scale
   return emb_scale, num_head_scale, mlp_dim_scale, layer_scale
 
+def get_batch_sizes(per_device_batch_size):
+  num_devices = len(jax.devices())
+  if per_device_batch_size < 1:
+    # For per_device_batch_size<1, we load the data as if per_device_batch_size=1
+    batch_size_to_load = num_devices
+  else:
+    batch_size_to_load = int(num_devices * per_device_batch_size)
 
+  batch_size_to_train_on = int(num_devices * per_device_batch_size)
+  return batch_size_to_load, batch_size_to_train_on
 
 class HyperParameters(): # pylint: disable=missing-class-docstring
   def __init__(self):

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -167,7 +167,7 @@ def train_step(model, config, state, data, dropout_rng, batch_size):
   # inputs, targets, segments, positions = apply_args
   rng1, gen_aqt_rng = jax.random.split(dropout_rng)
   aqt_rng, rng2 = jax.random.split(gen_aqt_rng)
-  
+
   if config.per_device_batch_size < 1:
     # decimate data by proportion of per_device_batch_size
     for k, v in data.items():

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -169,7 +169,7 @@ def train_step(model, config, state, data, dropout_rng):
 
   # decimate proportion of data when per_device_batch_size<1
   for k, v in data.items():
-    data[k] = v[:config.batch_size_to_train_on,:]
+    data[k] = v[:config.global_batch_size_to_train_on,:]
 
   def loss_fn(params):
     logits, intermediate_outputs = model.apply({'params': params},

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -167,10 +167,9 @@ def train_step(model, config, state, data, dropout_rng):
   rng1, gen_aqt_rng = jax.random.split(dropout_rng)
   aqt_rng, rng2 = jax.random.split(gen_aqt_rng)
 
-  if config.per_device_batch_size < 1:
-    # decimate data by proportion of per_device_batch_size
-    for k, v in data.items():
-      data[k] = v[:config.batch_size_to_train_on,:]
+  # decimate proportion of data when per_device_batch_size<1
+  for k, v in data.items():
+    data[k] = v[:config.batch_size_to_train_on,:]
 
   def loss_fn(params):
     logits, intermediate_outputs = model.apply({'params': params},

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -148,7 +148,7 @@ def record_activation_metrics(output_metrics, intermediate_outputs, config):
       output_metrics['scalar'][f'activ_mean/layer_{layer_num:03d}'] = layer["activation_mean"][0]
       output_metrics['scalar'][f'activ_stdev/layer_{layer_num:03d}'] = layer["activation_stdev"][0]
 
-def train_step(model, config, state, data, dropout_rng, batch_size):
+def train_step(model, config, state, data, dropout_rng):
   """
 
   Args:
@@ -170,6 +170,7 @@ def train_step(model, config, state, data, dropout_rng, batch_size):
 
   if config.per_device_batch_size < 1:
     # decimate data by proportion of per_device_batch_size
+    batch_size = max_utils.calculate_raw_input_batch_size(config.per_device_batch_size)
     for k, v in data.items():
       data[k] = v[:batch_size,:]
 
@@ -266,7 +267,7 @@ def train_loop(config, state=None):
                        data_pspec,
                        None),
     out_shardings=(state_mesh_annotations, None, None),
-    static_argnums=(0,1,5,),
+    static_argnums=(0,1,),
     donate_argnums=2)
 
   example_batch = None
@@ -275,13 +276,11 @@ def train_loop(config, state=None):
   local_metrics_file = open(config.metrics_file, 'a', encoding="utf8") if config.metrics_file else None
   running_gcs_metrics = [] if config.gcs_metrics else None
 
-  batch_size = int(config.per_device_batch_size * mesh.size)
-
   for step in np.arange(get_first_step(state), config.steps):
     example_batch = load_next_batch(train_iter, example_batch, config)
     with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
       state, metrics, nextrng = p_train_step(
-          model, config, state, example_batch, nextrng, batch_size
+          model, config, state, example_batch, nextrng
       )
 
     new_time = datetime.datetime.now()

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -173,11 +173,6 @@ def train_step(model, config, state, data, dropout_rng, batch_size):
     for k, v in data.items():
       data[k] = v[:batch_size,:]
 
-  if config.per_device_batch_size < 1:
-    # decimate data by proportion of per_device_batch_size
-    for k, v in data.items():
-      data[k] = v[:batch_size,:]
-
   def loss_fn(params):
     logits, intermediate_outputs = model.apply({'params': params},
                          data['inputs'],

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -173,6 +173,11 @@ def train_step(model, config, state, data, dropout_rng, batch_size):
     for k, v in data.items():
       data[k] = v[:batch_size,:]
 
+  if config.per_device_batch_size < 1:
+    # decimate data by proportion of per_device_batch_size
+    for k, v in data.items():
+      data[k] = v[:batch_size,:]
+
   def loss_fn(params):
     logits, intermediate_outputs = model.apply({'params': params},
                          data['inputs'],

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -169,9 +169,8 @@ def train_step(model, config, state, data, dropout_rng):
 
   if config.per_device_batch_size < 1:
     # decimate data by proportion of per_device_batch_size
-    batch_size = max_utils.calculate_raw_input_batch_size(config.per_device_batch_size)
     for k, v in data.items():
-      data[k] = v[:batch_size,:]
+      data[k] = v[:config.batch_size_to_train_on,:]
 
   def loss_fn(params):
     logits, intermediate_outputs = model.apply({'params': params},

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -156,7 +156,6 @@ def train_step(model, config, state, data, dropout_rng):
     state: A pytree of the current state of the model
     data: Batch of data to apply to the model
     dropout_rng: A key to use to generate rng for dropout
-    batch_size: Global batch size
 
   Returns:
     new_state: Same format as state.


### PR DESCRIPTION
Support `per_device_batch_size<1` by loading the data as if `per_device_batch_size=1` and then decimating proportion of the data based on `per_device_batch_size` in `train_step`.