### PR TITLE
[WIP] Llama2 Integration

### DIFF
--- a/MaxText/llama2.py
+++ b/MaxText/llama2.py
@@ -1,0 +1,1105 @@
+"""
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+"""Transformer model definition."""
+# pylint: disable=arguments-differ
+
+from aqt.jax.v2 import aqt_dot_general as aqt
+from aqt.jax.v2 import config as aqt_config
+
+import dataclasses
+import functools
+import operator
+from typing import Any, Callable, Iterable, Optional, Sequence, Tuple, Union
+
+
+from flax import linen as nn
+from flax.linen import partitioning as nn_partitioning
+
+import numpy as np
+
+import jax
+from jax import lax
+from jax import random
+from jax.ad_checkpoint import checkpoint_name
+import jax.numpy as jnp
+
+
+
+
+withLP = nn.with_logical_partitioning
+ScanIn = nn_partitioning.ScanIn
+
+Config = Any
+
+# Type annotations
+Array = jnp.ndarray
+DType = jnp.dtype
+PRNGKey = jnp.ndarray
+Shape = Iterable[int]
+Activation = Callable[..., Array]
+# Parameter initializers.
+Initializer = Callable[[PRNGKey, Shape, DType], Array]
+InitializerAxis = Union[int, Tuple[int, ...]]
+NdInitializer = Callable[
+    [PRNGKey, Shape, DType, InitializerAxis, InitializerAxis], Array]
+
+default_embed_init = nn.initializers.variance_scaling(
+    1.0, 'fan_in', 'normal', out_axis=0)
+
+
+#------------------------------------------------------------------------------
+# Dot product attention layer.
+#------------------------------------------------------------------------------
+
+#Llama2 helpers
+
+class RMSNorm(nn.Module):
+  """
+  Llama2 style RMSNorm
+  """
+  epsilon: float = 1e-6
+  dtype: Any = jnp.bfloat16
+  kernel_axes: Tuple[str, ...] = ()
+  scale_init: Initializer = nn.initializers.ones
+
+  @nn.compact
+  def __call__(self, x:jnp.ndarray) -> jnp.ndarray:
+    """
+    Applies Llama2 style RMS normalization to the input
+    """
+    x = jnp.asarray(x, self.dtype)
+    features = x.shape[-1]
+    x_rms = jnp.sqrt((x * x).mean(axis=-1, keepdims=True) + self.epsilon)
+    y = jnp.asarray(x / x_rms, self.dtype)
+    scale = self.param(
+        'scale', withLP(self.scale_init, self.kernel_axes), (features,), self.dtype)
+
+    scale = jnp.asarray(scale, self.dtype)
+    return y * scale
+
+
+class RotaryEmbedding(nn.Module):
+  min_timescale: int = 1
+  max_timescale: int = 10_000
+  embedding_dims: int = 0
+
+  def __call__(
+      self,
+      inputs: jnp.ndarray,
+      position: Optional[jnp.ndarray] = None
+  ) -> jnp.ndarray:
+    
+    embedding_dims = inputs.shape[-1]
+    half_embedding_dim = embedding_dims // 2
+    fraction = 2 * jnp.arange(0,half_embedding_dim) / embedding_dims
+
+    timescale = (
+        self.min_timescale
+        * (self.max_timescale / self.min_timescale) ** fraction
+    )
+    if position is None:
+      seq_length = inputs.shape[1]
+      position = jnp.arange(seq_length, dtype=jnp.float32)[jnp.newaxis, :]
+    position = position[:, :, jnp.newaxis, jnp.newaxis]
+    timescale = timescale[jnp.newaxis, jnp.newaxis, jnp.newaxis, :]
+    sinusoid_inp = position / timescale
+    sin = jnp.sin(sinusoid_inp)
+    cos = jnp.cos(sinusoid_inp)
+    first_half, second_half = jnp.split(inputs, 2, axis=-1)
+    first_part = (first_half * cos - second_half * sin)
+    second_part = (second_half * cos + first_half * sin)
+
+    return jnp.concatenate([first_part, second_part], axis=-1)
+
+
+def dot_product_attention(query: Array,
+                          key: Array,
+                          value: Array,
+                          bias: Optional[Array] = None,
+                          dropout_rng: Optional[PRNGKey] = None,
+                          dropout_rate: float = 0.,
+                          deterministic: bool = False,
+                          dtype: DType = jnp.float32,
+                          float32_logits: bool = False):
+  """Computes dot-product attention given query, key, and value.
+
+  This is the core function for applying attention based on
+  https://arxiv.org/abs/1706.03762. It calculates the attention weights given
+  query and key and combines the values using the attention weights.
+
+  Args:
+    query: queries for calculating attention with shape of `[batch, q_length,
+      num_heads, qk_depth_per_head]`.
+    key: keys for calculating attention with shape of `[batch, kv_length,
+      num_heads, qk_depth_per_head]`.
+    value: values to be used in attention with shape of `[batch, kv_length,
+      num_heads, v_depth_per_head]`.
+    bias: bias for the attention weights. This should be broadcastable to the
+      shape `[batch, num_heads, q_length, kv_length]` This can be used for
+      incorporating causal masks, padding masks, proximity bias, etc.
+    dropout_rng: JAX PRNGKey: to be used for dropout
+    dropout_rate: dropout rate
+    deterministic: bool, deterministic or not (to apply dropout)
+    dtype: the dtype of the computation (default: float32)
+    float32_logits: bool, if True then compute logits in float32 to avoid
+      numerical issues with bfloat16.
+
+  Returns:
+    Output of shape `[batch, length, num_heads, v_depth_per_head]`.
+  """
+  assert key.ndim == query.ndim == value.ndim, 'q, k, v must have same rank.'
+  assert query.shape[:-3] == key.shape[:-3] == value.shape[:-3], (
+      'q, k, v batch dims must match.')
+  assert query.shape[-2] == key.shape[-2] == value.shape[-2], (
+      'q, k, v num_heads must match.')
+  assert key.shape[-3] == value.shape[-3], 'k, v lengths must match.'
+  assert query.shape[-1] == key.shape[-1], 'q, k depths must match.'
+
+  # Casting logits and softmax computation for float32 for model stability.
+  if float32_logits:
+    query = query.astype(jnp.float32)
+    key = key.astype(jnp.float32)
+  # Layer norms here prevent (near) one-hot softmaxes, which can lead to
+  # unstable training loss and nans, see the "QK Normalization" subsection in
+  # https://arxiv.org/pdf/2302.05442.pdf.
+  query = RMSNorm(dtype=dtype, name='query_layer_norm', kernel_axes = ('heads',))(query)
+  key = RMSNorm(dtype=dtype, name='key_layer_norm', kernel_axes = ('heads',))(key)
+
+  # `attn_weights`: [batch, num_heads, q_length, kv_length]
+  attn_weights = jnp.einsum('bqhd,bkhd->bhqk', query, key)
+
+  # Apply attention bias: masking, dropout, proximity bias, etc.
+  if bias is not None:
+    attn_weights = attn_weights + bias.astype(attn_weights.dtype)
+
+  # Normalize the attention weights across `kv_length` dimension.
+  attn_weights = jax.nn.softmax(attn_weights).astype(dtype)
+
+  # Apply attention dropout.
+  if not deterministic and dropout_rate > 0.:
+    keep_prob = 1.0 - dropout_rate
+    # Broadcast dropout mask along the query dim.
+    dropout_shape = list(attn_weights.shape)
+    dropout_shape[-2] = 1
+    keep = random.bernoulli(dropout_rng, keep_prob, dropout_shape)
+    keep = jnp.broadcast_to(keep, attn_weights.shape)
+    multiplier = (
+        keep.astype(attn_weights.dtype) / jnp.asarray(keep_prob, dtype=dtype))
+    attn_weights = attn_weights * multiplier
+
+  # Take the linear combination of `value`.
+  return jnp.einsum('bhqk,bkhd->bqhd', attn_weights, value)
+
+
+dynamic_vector_slice_in_dim = jax.vmap(
+    lax.dynamic_slice_in_dim, in_axes=(None, 0, None, None))
+
+
+#------------------------------------------------------------------------------
+# DenseGeneral for attention layers.
+#------------------------------------------------------------------------------
+
+
+def nd_dense_init(scale, mode, distribution):
+  """Initializer with in_axis, out_axis set at call time."""
+  def init_fn(key, shape, dtype, in_axis, out_axis):
+    fn = jax.nn.initializers.variance_scaling(
+        scale, mode, distribution, in_axis, out_axis)
+    return fn(key, shape, dtype)
+  return init_fn
+
+
+def _normalize_axes(axes: Iterable[int], ndim: int) -> Tuple[int]:
+  # A tuple by convention. len(axes_tuple) then also gives the rank efficiently.
+  return tuple(ax if ax >= 0 else ndim + ax for ax in axes)
+
+
+def _canonicalize_tuple(x):
+  if isinstance(x, Iterable):
+    return tuple(x)
+  else:
+    return (x,)
+
+
+class DenseGeneral(nn.Module):
+  """A linear transformation (without bias) with flexible axes.
+
+    Attributes:
+      features: tuple with numbers of output features.
+      axis: tuple with axes to apply the transformation on.
+      dtype: the dtype of the computation (default: float32).
+      kernel_init: initializer function for the weight matrix.
+  """
+  features: Union[Iterable[int], int]
+  config: Config
+  axis: Union[Iterable[int], int] = -1
+  dtype: DType = jnp.float32
+  kernel_init: NdInitializer = nd_dense_init(1.0, 'fan_in', 'truncated_normal')
+  kernel_axes: Tuple[str, ...] = ()
+
+  @nn.compact
+  def __call__(self, inputs: Array) -> Array:
+    """Applies a linear transformation to the inputs along multiple dimensions.
+
+    Args:
+      inputs: The nd-array to be transformed.
+
+    Returns:
+      The transformed input.
+    """
+    cfg = self.config
+    features = _canonicalize_tuple(self.features)
+    axis = _canonicalize_tuple(self.axis)
+
+    inputs = jnp.asarray(inputs, self.dtype)
+    axis = _normalize_axes(axis, inputs.ndim)
+
+    kernel_shape = tuple(inputs.shape[ax] for ax in axis) + features
+    kernel_in_axis = np.arange(len(axis))
+    kernel_out_axis = np.arange(len(axis), len(axis) + len(features))
+    kernel = self.param(
+        'kernel',
+        withLP(self.kernel_init, self.kernel_axes),
+        kernel_shape,
+        jnp.float32,
+        kernel_in_axis,
+        kernel_out_axis)
+    kernel = jnp.asarray(kernel, self.dtype)
+
+    contract_ind = tuple(range(0, len(axis)))
+
+    if not cfg.use_int8_training:
+      return lax.dot_general(inputs, kernel, ((axis, contract_ind), ((), ())))
+    else:
+      aqt_cfg = aqt_config.fully_quantized(bits=8, use_fwd_quant=True)
+
+      def noise_fn(shape, key):
+        return jax.random.uniform(key, shape) - 0.5
+
+      aqt_cfg.dlhs.lhs.noise_fn = noise_fn
+      aqt_cfg.dlhs.rhs.noise_fn = noise_fn
+      aqt_cfg.drhs.lhs.noise_fn = noise_fn
+      aqt_cfg.drhs.rhs.noise_fn = noise_fn
+
+      aqt_dot_general = aqt.make_dot_general(aqt_cfg)
+      aqt_key = self.make_rng('aqt')
+      context = aqt.Context(key=aqt_key, train_step=None)
+
+      return aqt_dot_general(inputs, kernel, ((axis, contract_ind), ((), ())), context=context)
+
+def _convert_to_activation_function(
+    fn_or_string: Union[str, Callable]) -> Callable:
+  """Convert a string to an activation function."""
+  if fn_or_string == 'linear':
+    return lambda x: x
+  elif isinstance(fn_or_string, str):
+    return getattr(nn, fn_or_string)
+  elif callable(fn_or_string):
+    return fn_or_string
+  else:
+    raise ValueError(f"""Don't know how to convert {fn_or_string}
+                         to an activation function""")
+
+
+class MultiHeadDotProductAttention(nn.Module):
+  """Multi-head dot-product attention.
+
+    Attributes:
+      num_heads: number of attention heads. Features (i.e. inputs_q.shape[-1])
+        should be divisible by the number of heads.
+      head_dim: dimension of each head.
+      dtype: the dtype of the computation.
+      dropout_rate: dropout rate
+      kernel_init: initializer for the kernel of the Dense layers.
+      float32_logits: bool, if True then compute logits in float32 to avoid
+        numerical issues with bfloat16.
+  """
+
+  num_heads: int
+  head_dim: int
+  config: Config
+  dtype: DType = jnp.float32
+  dropout_rate: float = 0.
+  kernel_init: NdInitializer = nd_dense_init(1.0, 'fan_in', 'normal')
+  float32_logits: bool = False  # computes logits in float32 for stability.
+
+  @nn.compact
+  def __call__(self,
+               inputs_q: Array,
+               inputs_kv: Array,
+               mask: Optional[Array] = None,
+               bias: Optional[Array] = None,
+               *,
+               decode: bool = False,
+               deterministic: bool = False) -> Array:
+    """Applies multi-head dot product attention on the input data.
+
+    Projects the inputs into multi-headed query, key, and value vectors,
+    applies dot-product attention and project the results to an output vector.
+
+    There are two modes: decoding and non-decoding (e.g., training). The mode is
+    determined by `decode` argument. For decoding, this method is called twice,
+    first to initialize the cache and then for an actual decoding process. The
+    two calls are differentiated by the presence of 'cached_key' in the variable
+    dict. In the cache initialization stage, the cache variables are initialized
+    as zeros and will be filled in the subsequent decoding process.
+
+    In the cache initialization call, `inputs_q` has a shape [batch, length,
+    q_features] and `inputs_kv`: [batch, length, kv_features]. During the
+    incremental decoding stage, query, key and value all have the shape [batch,
+    1, qkv_features] corresponding to a single step.
+
+    Args:
+      inputs_q: input queries of shape `[batch, q_length, q_features]`.
+      inputs_kv: key/values of shape `[batch, kv_length, kv_features]`.
+      mask: attention mask of shape `[batch, num_heads, q_length, kv_length]`.
+      bias: attention bias of shape `[batch, num_heads, q_length, kv_length]`.
+      decode: Whether to prepare and use an autoregressive cache.
+      deterministic: Disables dropout if set to True.
+
+    Returns:
+      output of shape `[batch, length, q_features]`.
+    """
+    cfg = self.config
+
+    projection = functools.partial(
+        DenseGeneral,
+        axis=-1,
+        features=(self.num_heads, self.head_dim),
+        kernel_axes=('embed', 'heads', 'kv'),
+        dtype=self.dtype,
+        config=cfg)
+
+    # NOTE: T5 does not explicitly rescale the attention logits by
+    #       1/sqrt(depth_kq)!  This is folded into the initializers of the
+    #       linear transformations, which is equivalent under Adafactor.
+    depth_scaling = jnp.sqrt(self.head_dim).astype(self.dtype)
+    def query_init(*args):
+      #pylint: disable=no-value-for-parameter
+      return self.kernel_init(*args) / depth_scaling
+
+    # Project inputs_q to multi-headed q/k/v
+    # dimensions are then [batch, length, num_heads, head_dim]
+    query = projection(kernel_init=query_init, name='query')(inputs_q)
+    key = projection(kernel_init=self.kernel_init, name='key')(inputs_kv)
+    value = projection(kernel_init=self.kernel_init, name='value')(inputs_kv)
+
+    #Apply ROPE
+    query = RotaryEmbedding(embedding_dims = self.head_dim, name='query_rotary')(query)
+    key = RotaryEmbedding(embedding_dims = self.head_dim, name='key_rotary')(key)
+
+
+
+    query = nn.with_logical_constraint(
+        query, ('activation_batch', 'activation_length', 'activation_heads', 'activation_kv')
+    )
+    query = checkpoint_name(query, 'query_proj')
+    key = nn.with_logical_constraint(key, ('activation_batch', 'activation_length', 'activation_heads', 'activation_kv'))
+    key = checkpoint_name(key, 'key_proj')
+    value = nn.with_logical_constraint(
+        value, ('activation_batch', 'activation_length', 'activation_heads', 'activation_kv')
+    )
+    value = checkpoint_name(value, 'value_proj')
+
+    if decode:
+      # Detect if we're initializing by absence of existing cache data.
+      is_initialized = self.has_variable('cache', 'cached_key')
+      # The key and value have dimension [batch, length, num_heads, head_dim],
+      # but we cache them as [batch, num_heads, head_dim, length] as a TPU
+      # fusion optimization. This also enables the "scatter via one-hot
+      # broadcast" trick, which means we do a one-hot broadcast instead of a
+      # scatter/gather operations, resulting in a 3-4x speedup in practice.
+      def swap_dims(x):
+        return x[:-3] + tuple(x[i] for i in [-2, -1, -3])
+      cached_key = self.variable('cache', 'cached_key', jnp.zeros,
+                                 swap_dims(key.shape), key.dtype)
+      cached_value = self.variable('cache', 'cached_value', jnp.zeros,
+                                   swap_dims(value.shape), value.dtype)
+      cache_index = self.variable('cache', 'cache_index',
+                                  lambda: jnp.array(0, dtype=jnp.int32))
+      if is_initialized:
+        batch, num_heads, head_dim, length = cached_key.value.shape
+        # During fast autoregressive decoding, we feed one position at a time,
+        # and cache the keys and values step by step.
+        # Sanity shape check of cached key against input query.
+        expected_shape = (batch, 1, num_heads, head_dim)
+        if expected_shape != query.shape:
+          raise ValueError(f"""Autoregressive cache shape error,
+                           expected query shape %s instead got 
+                           {(expected_shape, query.shape)}""")
+        # Create a OHE of the current index. NOTE: the index is increased below.
+        cur_index = cache_index.value
+        one_hot_indices = jax.nn.one_hot(cur_index, length, dtype=key.dtype)
+        # In order to update the key, value caches with the current key and
+        # value, we move the length axis to the back, similar to what we did for
+        # the cached ones above.
+        # Note these are currently the key and value of a single position, since
+        # we feed one position at a time.
+        one_token_key = jnp.moveaxis(key, -3, -1)
+        one_token_value = jnp.moveaxis(value, -3, -1)
+        # Update key, value caches with our new 1d spatial slices.
+        # We implement an efficient scatter into the cache via one-hot
+        # broadcast and addition.
+        key = cached_key.value + one_token_key * one_hot_indices
+        value = cached_value.value + one_token_value * one_hot_indices
+        cached_key.value = key
+        cached_value.value = value
+        cache_index.value = cache_index.value + 1
+        # Move the keys and values back to their original shapes.
+        key = jnp.moveaxis(key, -1, -3)
+        value = jnp.moveaxis(value, -1, -3)
+
+        # Causal mask for cached decoder self-attention: our single query
+        # position should only attend to those key positions that have already
+        # been generated and cached, not the remaining zero elements.
+        mask = combine_masks(
+            mask,
+            jnp.broadcast_to(
+                jnp.arange(length) <= cur_index,
+                # (1, 1, length) represent (head dim, query length, key length)
+                # query length is 1 because during decoding we deal with one
+                # index.
+                # The same mask is applied to all batch elements and heads.
+                (batch, 1, 1, length)))
+
+        # Grab the correct relative attention bias during decoding. This is
+        # only required during single step decoding.
+        if bias is not None:
+          # The bias is a full attention matrix, but during decoding we only
+          # have to take a slice of it.
+          # This is equivalent to bias[..., cur_index:cur_index+1, :].
+          bias = dynamic_vector_slice_in_dim(
+              jnp.squeeze(bias, axis=0), jnp.reshape(cur_index, (-1)), 1, -2)
+
+    # Convert the boolean attention mask to an attention bias.
+    if mask is not None:
+      # attention mask in the form of attention bias
+      attention_bias = lax.select(
+          mask > 0,
+          jnp.full(mask.shape, 0.).astype(self.dtype),
+          jnp.full(mask.shape, -1e10).astype(self.dtype))
+    else:
+      attention_bias = None
+
+    # Add provided bias term (e.g. relative position embedding).
+    if bias is not None:
+      attention_bias = combine_biases(attention_bias, bias)
+
+    dropout_rng = None
+    if not deterministic and self.dropout_rate > 0.:
+      dropout_rng = self.make_rng('dropout')
+
+    # Apply attention.
+    x = dot_product_attention(
+        query,
+        key,
+        value,
+        bias=attention_bias,
+        dropout_rng=dropout_rng,
+        dropout_rate=self.dropout_rate,
+        deterministic=deterministic,
+        dtype=self.dtype,
+        float32_logits=self.float32_logits)
+
+    # Back to the original inputs dimensions.
+    out = DenseGeneral(
+        features=inputs_q.shape[-1],  # output dim is set to the input dim.
+        axis=(-2, -1),
+        kernel_init=self.kernel_init,
+        kernel_axes=('heads', 'kv', 'embed'),
+        dtype=self.dtype,
+        name='out',
+        config=cfg)(
+            x)
+    return out
+
+
+
+
+
+class MlpBlock(nn.Module):
+  """Transformer MLP / feed-forward block.
+
+  Attributes:
+    intermediate_dim: Shared dimension of hidden layers.
+    activations: Type of activations for each layer.  Each element is either
+      'linear', a string function name in flax.linen, or a function.
+    kernel_init: Kernel function, passed to the dense layers.
+    deterministic: Whether the dropout layers should be deterministic.
+    intermediate_dropout_rate: Dropout rate used after the intermediate layers.
+    dtype: Type for the dense layer.
+  """
+  config: Config
+  intermediate_dim: int = 2048
+  activations: Sequence[Union[str, Callable]] = ('silu',)
+  kernel_init: NdInitializer = nd_dense_init(1.0, 'fan_in', 'truncated_normal')
+  intermediate_dropout_rate: float = 0.1
+  dtype: Any = jnp.float32
+
+  @nn.compact
+  def __call__(self, inputs, decode: bool = False, deterministic: bool = False):
+    """Applies Transformer MlpBlock module."""
+    cfg = self.config
+
+    # Iterate over specified MLP input activation functions.
+    # e.g. ('relu',) or ('gelu', 'linear') for gated-gelu.
+    activations = []
+    for idx, act_fn in enumerate(self.activations):
+      dense_name = 'wi' if len(self.activations) == 1 else f'wi_{idx}'
+      x = DenseGeneral(
+          self.intermediate_dim,
+          dtype=self.dtype,
+          kernel_init=self.kernel_init,
+          kernel_axes=('embed', 'mlp'),
+          name=dense_name,
+          config=cfg)(
+              inputs)
+      x = _convert_to_activation_function(act_fn)(x)
+      activations.append(x)
+
+    # Take elementwise product of above intermediate activations.
+    x = functools.reduce(operator.mul, activations)
+    # Apply dropout and final dense output projection.
+    x = nn.Dropout(
+        rate=self.intermediate_dropout_rate, broadcast_dims=(-2,))(
+            x, deterministic=deterministic)  # Broadcast along length.
+    x = nn.with_logical_constraint(x, ('activation_batch', 'activation_length', 'activation_mlp'))
+    output = DenseGeneral(
+        inputs.shape[-1],
+        dtype=self.dtype,
+        kernel_init=self.kernel_init,
+        kernel_axes=('mlp', 'embed'),
+        name='wo',
+        config=cfg)(
+            x)
+    return output
+
+
+
+#------------------------------------------------------------------------------
+# Utils
+#------------------------------------------------------------------------------
+
+class Embed(nn.Module):
+  """A parameterized function from integers [0, n) to d-dimensional vectors.
+
+  Attributes:
+    num_embeddings: number of embeddings.
+    features: number of feature dimensions for each embedding.
+    dtype: the dtype of the embedding vectors (default: float32).
+    embedding_init: embedding initializer.
+  """
+  num_embeddings: int
+  features: int
+  cast_input_dtype: Optional[DType] = None
+  dtype: DType = jnp.float32
+  attend_dtype: Optional[DType] = None
+  embedding_init: Initializer = default_embed_init
+  embedding: Array = dataclasses.field(init=False)
+
+  def setup(self):
+    self.embedding = self.param(
+        'embedding',
+        withLP(self.embedding_init, ('vocab', 'embed')),
+        (self.num_embeddings, self.features),
+        jnp.float32)
+
+  def __call__(self, inputs: Array) -> Array:
+    """Embeds the inputs along the last dimension.
+
+    Args:
+      inputs: input data, all dimensions are considered batch dimensions.
+
+    Returns:
+      Output which is embedded input data.  The output shape follows the input,
+      with an additional `features` dimension appended.
+    """
+    if self.cast_input_dtype:
+      inputs = inputs.astype(self.cast_input_dtype)
+    if not jnp.issubdtype(inputs.dtype, jnp.integer):
+      raise ValueError('Input type must be an integer or unsigned integer.')
+    output = jnp.asarray(self.embedding, self.dtype)[inputs]
+    output = nn.with_logical_constraint(output, ('activation_batch', 'activation_length', 'activation_embed'))
+    return output
+
+  def attend(self, query: Array) -> Array:
+    """Attend over the embedding using a query array.
+
+    Args:
+      query: array with last dimension equal the feature depth `features` of the
+        embedding.
+
+    Returns:
+      An array with final dim `num_embeddings` corresponding to the batched
+      inner-product of the array of query vectors against each embedding.
+      Commonly used for weight-sharing between embeddings and logit transform
+      in NLP models.
+    """
+    dtype = self.attend_dtype if self.attend_dtype is not None else self.dtype
+    return jnp.dot(query, jnp.asarray(self.embedding, dtype).T)
+
+
+
+#------------------------------------------------------------------------------
+# Mask-making utility functions.
+#------------------------------------------------------------------------------
+def make_attention_mask(query_input: Array,
+                        key_input: Array,
+                        pairwise_fn: Callable = jnp.multiply,
+                        extra_batch_dims: int = 0,
+                        dtype: DType = jnp.float32) -> Array:
+  """Mask-making helper for attention weights.
+
+  In case of 1d inputs (i.e., `[batch, len_q]`, `[batch, len_kv]`, the
+  attention weights will be `[batch, heads, len_q, len_kv]` and this
+  function will produce `[batch, 1, len_q, len_kv]`.
+
+  Args:
+    query_input: a batched, flat input of query_length size
+    key_input: a batched, flat input of key_length size
+    pairwise_fn: broadcasting elementwise comparison function
+    extra_batch_dims: number of extra batch dims to add singleton axes for, none
+      by default
+    dtype: mask return dtype
+
+  Returns:
+    A `[batch, 1, len_q, len_kv]` shaped mask for 1d attention.
+  """
+  # [batch, len_q, len_kv]
+  mask = pairwise_fn(
+      # [batch, len_q] -> [batch, len_q, 1]
+      jnp.expand_dims(query_input, axis=-1),
+      # [batch, len_q] -> [batch, 1, len_kv]
+      jnp.expand_dims(key_input, axis=-2))
+
+  # [batch, 1, len_q, len_kv]. This creates the head dim.
+  mask = jnp.expand_dims(mask, axis=-3)
+  mask = jnp.expand_dims(mask, axis=tuple(range(extra_batch_dims)))
+  return mask.astype(dtype)
+
+
+def make_causal_mask(x: Array,
+                     extra_batch_dims: int = 0,
+                     dtype: DType = jnp.float32) -> Array:
+  """Make a causal mask for self-attention.
+
+  In case of 1d inputs (i.e., `[batch, len]`, the self-attention weights
+  will be `[batch, heads, len, len]` and this function will produce a
+  causal mask of shape `[batch, 1, len, len]`.
+
+  Note that a causal mask does not depend on the values of x; it only depends on
+  the shape. If x has padding elements, they will not be treated in a special
+  manner.
+
+  Args:
+    x: input array of shape `[batch, len]`
+    extra_batch_dims: number of batch dims to add singleton axes for, none by
+      default
+    dtype: mask return dtype
+
+  Returns:
+    A `[batch, 1, len, len]` shaped causal mask for 1d attention.
+  """
+  idxs = jnp.broadcast_to(jnp.arange(x.shape[-1], dtype=jnp.int32), x.shape)
+  return make_attention_mask(
+      idxs,
+      idxs,
+      jnp.greater_equal,
+      extra_batch_dims=extra_batch_dims,
+      dtype=dtype)
+
+
+def combine_masks(*masks: Optional[Array], dtype: DType = jnp.float32):
+  """Combine attention masks.
+
+  Args:
+    *masks: set of attention mask arguments to combine, some can be None.
+    dtype: final mask dtype
+
+  Returns:
+    Combined mask, reduced by logical and, returns None if no masks given.
+  """
+  masks = [m for m in masks if m is not None]
+  if not masks:
+    return None
+  assert all(map(lambda x: x.ndim == masks[0].ndim, masks)), (
+      f'masks must have same rank: {tuple(map(lambda x: x.ndim, masks))}')
+  mask, *other_masks = masks
+  for other_mask in other_masks:
+    mask = jnp.logical_and(mask, other_mask)
+  return mask.astype(dtype)
+
+
+def combine_biases(*masks: Optional[Array]):
+  """Combine attention biases.
+
+  Args:
+    *masks: set of attention bias arguments to combine, some can be None.
+
+  Returns:
+    Combined mask, reduced by summation, returns None if no masks given.
+  """
+  masks = [m for m in masks if m is not None]
+  if not masks:
+    return None
+  assert all(map(lambda x: x.ndim == masks[0].ndim, masks)), (
+      f'masks must have same rank: {tuple(map(lambda x: x.ndim, masks))}')
+  mask, *other_masks = masks
+  for other_mask in other_masks:
+    mask = mask + other_mask
+  return mask
+
+
+def make_decoder_mask(decoder_target_tokens: Array,
+                      dtype: DType,
+                      decoder_causal_attention: Optional[Array] = None,
+                      decoder_segment_ids: Optional[Array] = None) -> Array:
+  """Compute the self-attention mask for a decoder.
+
+  Decoder mask is formed by combining a causal mask, a padding mask and an
+  optional packing mask. If decoder_causal_attention is passed, it makes the
+  masking non-causal for positions that have value of 1.
+
+  A prefix LM is applied to a dataset which has a notion of "inputs" and
+  "targets", e.g., a machine translation task. The inputs and targets are
+  concatenated to form a new target. `decoder_target_tokens` is the concatenated
+  decoder output tokens.
+
+  The "inputs" portion of the concatenated sequence can attend to other "inputs"
+  tokens even for those at a later time steps. In order to control this
+  behavior, `decoder_causal_attention` is necessary. This is a binary mask with
+  a value of 1 indicating that the position belonged to "inputs" portion of the
+  original dataset.
+
+  Example:
+
+    Suppose we have a dataset with two examples.
+
+    ds = [{"inputs": [6, 7], "targets": [8]},
+          {"inputs": [3, 4], "targets": [5]}]
+
+    After the data preprocessing with packing, the two examples are packed into
+    one example with the following three fields (some fields are skipped for
+    simplicity).
+
+       decoder_target_tokens = [[6, 7, 8, 3, 4, 5, 0]]
+         decoder_segment_ids = [[1, 1, 1, 2, 2, 2, 0]]
+    decoder_causal_attention = [[1, 1, 0, 1, 1, 0, 0]]
+
+    where each array has [batch, length] shape with batch size being 1. Then,
+    this function computes the following mask.
+
+                      mask = [[[[1, 1, 0, 0, 0, 0, 0],
+                                [1, 1, 0, 0, 0, 0, 0],
+                                [1, 1, 1, 0, 0, 0, 0],
+                                [0, 0, 0, 1, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 0, 0],
+                                [0, 0, 0, 1, 1, 1, 0],
+                                [0, 0, 0, 0, 0, 0, 0]]]]
+
+    mask[b, 1, :, :] represents the mask for the example `b` in the batch.
+    Because mask is for a self-attention layer, the mask's shape is a square of
+    shape [query length, key length].
+
+    mask[b, 1, i, j] = 1 means that the query token at position i can attend to
+    the key token at position j.
+
+  Args:
+    decoder_target_tokens: decoder output tokens. [batch, length]
+    dtype: dtype of the output mask.
+    decoder_causal_attention: a binary mask indicating which position should
+      only attend to earlier positions in the sequence. Others will attend
+      bidirectionally. [batch, length]
+    decoder_segment_ids: decoder segmentation info for packed examples. [batch,
+      length]
+
+  Returns:
+    the combined decoder mask.
+  """
+  masks = []
+  # The same mask is applied to all attention heads. So the head dimension is 1,
+  # i.e., the mask will be broadcast along the heads dim.
+  # [batch, 1, length, length]
+  causal_mask = make_causal_mask(decoder_target_tokens, dtype=dtype)
+
+  # Positions with value 1 in `decoder_causal_attneition` can attend
+  # bidirectionally.
+  if decoder_causal_attention is not None:
+    # [batch, 1, length, length]
+    inputs_mask = make_attention_mask(
+        decoder_causal_attention,
+        decoder_causal_attention,
+        jnp.logical_and,
+        dtype=dtype)
+    masks.append(jnp.logical_or(causal_mask, inputs_mask).astype(dtype))
+  else:
+    masks.append(causal_mask)
+
+  # Padding mask.
+  masks.append(
+      make_attention_mask(
+          decoder_target_tokens > 0, decoder_target_tokens > 0, dtype=dtype))
+
+  # Packing mask
+  if decoder_segment_ids is not None:
+    masks.append(
+        make_attention_mask(
+            decoder_segment_ids, decoder_segment_ids, jnp.equal, dtype=dtype))
+
+  return combine_masks(*masks, dtype=dtype)
+
+
+
+#------------------------------------------------------------------------------
+# The network: Decoder & Transformer Definitions
+#------------------------------------------------------------------------------
+
+
+class DecoderLayer(nn.Module):
+  """Transformer decoder layer that attends to the encoder."""
+  config: Config
+
+  @nn.compact
+  def __call__(self,
+               inputs,
+               decoder_mask,
+               deterministic,
+               decode,
+               max_decode_length):
+    cfg = self.config
+
+    # Relative position embedding as attention biases.
+    l = max_decode_length if decode and max_decode_length else inputs.shape[-2]
+    inputs = nn.with_logical_constraint(inputs, ('activation_batch', 'activation_length', 'activation_embed'))
+
+    # inputs: embedded inputs to the decoder with shape [batch, length, emb_dim]
+    lnx = RMSNorm(
+dtype=cfg.dtype, name='pre_self_attention_layer_norm', kernel_axes=('embed',))(
+            inputs)
+    lnx = nn.with_logical_constraint(lnx, ('activation_batch', 'activation_length', 'activation_embed'))
+
+    # Self-attention block
+    attention_lnx = MultiHeadDotProductAttention(
+        num_heads=cfg.num_heads,
+        dtype=cfg.dtype,
+        head_dim=cfg.head_dim,
+        dropout_rate=cfg.dropout_rate,
+        name='self_attention',
+        config=cfg)(
+            lnx,
+            lnx,
+            decoder_mask,
+            None, #No need of relpositionbias
+            deterministic=deterministic,
+            decode=decode)
+    attention_lnx = nn.with_logical_constraint(attention_lnx, ('activation_batch', 'activation_length', 'activation_embed'))
+
+    # MLP block.
+    mlp_lnx = MlpBlock(
+        intermediate_dim=cfg.mlp_dim,
+        activations=cfg.mlp_activations,
+        intermediate_dropout_rate=cfg.dropout_rate,
+        dtype=cfg.dtype,
+        name='mlp',
+        config=cfg,
+    )(lnx, deterministic=deterministic)
+    mlp_lnx = nn.with_logical_constraint(mlp_lnx, ('activation_batch', 'activation_length', 'activation_embed'))
+
+    next_layer_addition = mlp_lnx + attention_lnx
+
+    next_layer_addition_dropped_out = nn.Dropout(
+        rate=cfg.dropout_rate, broadcast_dims=(-2,))(
+            next_layer_addition, deterministic=deterministic)
+
+    layer_output = next_layer_addition_dropped_out + inputs
+    layer_output = nn.with_logical_constraint(layer_output, ('activation_batch', 'activation_length', 'activation_embed'))
+
+    if cfg.record_internal_nn_metrics:
+      self.sow('intermediates', 'activation_mean', jnp.mean(layer_output))
+      self.sow('intermediates', 'activation_stdev', jnp.std(layer_output))
+      self.sow('intermediates', 'activation_fraction_zero', jnp.sum(layer_output==0) / jnp.size(layer_output))
+
+    if cfg.scan_layers:
+      return layer_output, None
+    else:
+      return layer_output
+
+
+
+class Decoder(nn.Module):
+  """A stack of decoder layers as a part of an encoder-decoder architecture."""
+  config: Config
+  shared_embedding: nn.Module
+
+  @nn.compact
+  def __call__(self,
+               decoder_input_tokens,
+               decoder_positions=None,
+               decoder_mask=None,
+               deterministic=False,
+               decode=False,
+               max_decode_length=None):
+    cfg = self.config
+    assert decoder_input_tokens.ndim == 2  # [batch, len]
+
+    # [batch, length] -> [batch, length, emb_dim]
+    y = self.shared_embedding(decoder_input_tokens.astype('int32'))
+    y = nn.Dropout(
+        rate=cfg.dropout_rate, broadcast_dims=(-2,))(
+            y, deterministic=deterministic)
+    y = y.astype(cfg.dtype)
+
+    BlockLayer = DecoderLayer
+
+    if cfg.remat_policy != 'none':
+      if cfg.remat_policy == 'minimal':
+        policy = jax.checkpoint_policies.checkpoint_dots_with_no_batch_dims
+      elif cfg.remat_policy == 'proj':
+        policy = jax.checkpoint_policies.save_only_these_names(
+            'query_proj', 'value_proj', 'key_proj'
+        )
+      else:
+        assert cfg.remat_policy == 'full', "Remat policy needs to be on list of remat policies"
+        policy = None
+      BlockLayer = nn.remat(  # pylint: disable=invalid-name
+          BlockLayer,
+          prevent_cse=not cfg.scan_layers,
+          policy=policy,
+          static_argnums=(-1, -2, -3, -4))
+    if cfg.scan_layers:
+      initializing = self.is_mutable_collection('params')
+      params_spec = (
+          cfg.param_scan_axis if initializing else ScanIn(cfg.param_scan_axis))
+      cache_spec = 0
+      y, _ = nn.scan(
+          BlockLayer,
+          variable_axes={
+              'params': params_spec,
+              'cache': cache_spec,
+              'intermediates': 0
+          },
+          split_rngs={
+              'params': True,
+              'dropout': cfg.enable_dropout,
+              'aqt': cfg.use_int8_training
+          },
+          in_axes=(nn.broadcast, nn.broadcast, nn.broadcast,
+                   nn.broadcast),
+          length=cfg.num_decoder_layers,
+          metadata_params={nn.PARTITION_NAME: 'layers'})(
+              config=cfg,
+              name='decoder')(y, decoder_mask,
+                              deterministic, decode, max_decode_length)
+    else:
+      for lyr in range(cfg.num_decoder_layers):
+        # [batch, length, emb_dim] -> [batch, length, emb_dim]
+        y = BlockLayer(
+            config=cfg, name=f'layers_{lyr}')(
+                y,
+                decoder_mask,
+                deterministic,
+                decode,
+                max_decode_length)
+
+    y = RMSNorm(dtype=cfg.dtype, name='decoder_norm', kernel_axes = ('embed',))(y)
+    y = nn.Dropout(
+        rate=cfg.dropout_rate, broadcast_dims=(-2,))(
+            y, deterministic=deterministic)
+
+    # [batch, length, emb_dim] -> [batch, length, vocab_size]
+    if cfg.logits_via_embedding:
+      # Use the transpose of embedding matrix for logit transform.
+      logits = self.shared_embedding.attend(y)
+      # Correctly normalize pre-softmax logits for this shared case.
+      logits = logits / jnp.sqrt(y.shape[-1])
+    else:
+      logits = DenseGeneral(
+          cfg.vocab_size,
+          dtype=jnp.float32,  # Use float32 for stabiliity.
+          kernel_axes=('embed', 'vocab'),
+          name='logits_dense',
+          config=cfg)(
+              y)
+    logits = nn.with_logical_constraint(logits, ('activation_batch', 'activation_length', 'activation_vocab'))
+    return logits
+
+
+class Llama2(nn.Module):
+  """An decoder-only Transformer model."""
+  # pylint: disable=attribute-defined-outside-init
+  config: Config
+
+  def setup(self):
+    """Initialize shared_embedding, decoder"""
+    cfg = self.config
+    self.shared_embedding = Embed(
+        num_embeddings=cfg.vocab_size,
+        features=cfg.emb_dim,
+        dtype=cfg.dtype,
+        attend_dtype=jnp.float32,  # for logit training stability
+        embedding_init=nn.initializers.normal(stddev=1.0),
+        name='token_embedder')
+
+    self.decoder = Decoder(config=cfg, shared_embedding=self.shared_embedding)
+
+  def __call__(
+      self,
+      decoder_input_tokens,
+      decoder_target_tokens,
+      decoder_segment_ids=None,
+      decoder_positions=None,
+      enable_dropout=True,
+      decode=False,
+      max_decode_length=None):
+    """Applies Transformer decoder-branch on encoded-input and target."""
+    cfg = self.config
+
+    # Make padding attention masks.
+    if decode:
+      # Do not mask decoder attention based on targets padding at
+      # decoding/inference time.
+      decoder_mask = None
+    else:
+      decoder_mask = make_decoder_mask(
+          decoder_target_tokens=decoder_target_tokens,
+          dtype=cfg.dtype,
+          decoder_segment_ids=decoder_segment_ids)
+
+    # Add segmentation block-diagonal attention masks if using segmented data.
+    if decoder_segment_ids is not None:
+      if decode:
+        raise ValueError(
+            'During decoding, packing should not be used but '
+            '`encoder_segment_ids` was passed to `Transformer.decode`.')
+
+    logits = self.decoder(
+        decoder_input_tokens=decoder_input_tokens,
+        decoder_positions=decoder_positions,
+        decoder_mask=decoder_mask,
+        deterministic=not enable_dropout,
+        decode=decode,
+        max_decode_length=max_decode_length)
+    return logits
+
+
+def read_yml_file_and_convert(config_file_path:str):
+  import yaml
+  from ml_collections import config_dict
+  with open(config_file_path) as f:
+    config = yaml.load(f, Loader=yaml.FullLoader)
+  config = config_dict.ConfigDict(config)  
+  return config


### PR DESCRIPTION
The following PR adds Llama2 to architecture to MaxText to continue pretraining or train from scratch.
## TODO

- [ ] Add [Llama2](https://ai.meta.com/research/publications/llama-2-open-foundation-and-fine-tuned-chat-models/) architecture to `llama2.py`.     
- [ ] Add predefined config for different sizes(7B,13B and 70B).
- [ ] Add conversion script to convert hf weights to orbax checkpoint compatible weights