### PR TITLE
add adamW to int8-sweeps branch

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -171,11 +171,13 @@ enable_data_shuffling: True
 data_shuffle_seed: 0
 init_weights_seed: 0
 
-# Adam optimizer parameters
+# AdamW optimizer parameters
+# We use AdamW following Llama2's training details, see https://arxiv.org/pdf/2307.09288.pdf section 2.2
 adam_b1: 0.9 # Exponential decay rate to track the first moment of past gradients.
 adam_b2: 0.95 # Exponential decay rate to track the second moment of past gradients.
 adam_eps: 1.e-8 # A small constant applied to denominator outside of the square root.
 adam_eps_root: 0. # A small constant applied to denominator inside the square root.
+adam_weight_decay: 0.1 # AdamW Weight decay
 
 # Stack trace parameters
 collect_stack_trace: True

--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -138,7 +138,7 @@ def decode_loop(config, state=None):
   # Model and Optimizer definition
   model = Transformer(config)
 
-  tx = optax.adam(
+  tx = optax.adamw(
     max_utils.create_learning_rate_schedule(
       learning_rate=config.learning_rate, warmup_steps=config.warmup_steps
     )

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -302,15 +302,16 @@ def train_loop(config, state=None):
       learning_rate=config.learning_rate, total_steps=config.learning_rate_schedule_steps
   )
 
-
-  adam = optax.adam(
+  # We use AdamW following Llama2's training details, see https://arxiv.org/pdf/2307.09288.pdf section 2.2
+  adam = optax.adamw(
       max_utils.create_learning_rate_schedule(
           learning_rate=config.learning_rate, total_steps=config.learning_rate_schedule_steps
       ),
       b1=config.adam_b1,
       b2=config.adam_b2,
       eps=config.adam_eps,
-      eps_root=config.adam_eps_root
+      eps_root=config.adam_eps_root,
+      weight_decay=config.adam_weight_decay,
   )
 
   # tx = optax.chain(


### PR DESCRIPTION
We follow Llama2 choice of weight_decay=0.1 but leave epsilon=1e-8 as it performs much better in MaxText 
Adam compared to AdamW with weight_decay=0.1
![image](https://github.com/google/maxtext/assets/51136315/8131c069-2ca3-47ca-8db9-07f5955f7cc7)

Epsilon Sweep:
![image](https://github.com/google/maxtext/assets/51136315/4221ebd4-5d03-44db-989a-8572323e4302)
