### PR TITLE
Enable Autocheckpoint and exit after saving an autocheckpoint

### DIFF
--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -132,7 +132,8 @@ def decode_loop(config, state=None):
   """Decoding loop for the Transformer model."""
   checkpoint_manager = checkpointing.create_orbax_checkpoint_manager(config.checkpoint_dir,
                                                                      config.enable_checkpointing,
-                                                                     config.async_checkpointing)
+                                                                     config.async_checkpointing,
+                                                                     config.save_period)
   rng = random.PRNGKey(0)
 
   # Mesh definition


### PR DESCRIPTION
This PR does two things:

1) Enable Autocheckpoint in MaxText. Along the way, the checkpoint manager is initialized in a more canonical way, with the option `save_interval_steps` passed as an option during creation.

2) Make the program exit after the checkpoint has been saved.

I have tested this PR to make sure that the full functionality of Autocheckpoint works as desired on two v4-8: a checkpointing process is automatically started upon a maintenance event, the program exits after saving the checkpoint, and the TPU goes through maintenance thereafter.