### PR TITLE
Add T5X xent and unit test

### DIFF
--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -247,3 +247,80 @@ def create_learning_rate_schedule(learning_rate: float, warmup_steps: int):
       rsqrt_schedule(init_value=learning_rate, shift=warmup_steps),
       ], boundaries=[warmup_steps],
       )
+
+from typing import Tuple, Mapping, Optional, Union
+
+
+
+@jax.custom_vjp
+def cross_entropy_with_logits(logits: jnp.ndarray, targets: jnp.ndarray,
+                              z_loss: float) -> Tuple[jnp.ndarray, jnp.ndarray]:
+  """Computes cross entropy loss with stable custom gradient.
+  Computes a stabilized-gradient version of:
+    -jnp.sum(targets * nn.log_softmax(logits), axis=-1)
+  If z_loss > 0, then an auxiliary loss equal to z_loss*log(z)^2
+  will be added to the cross entropy loss (z = softmax normalization constant).
+  The two uses of z_loss are:
+  1. To keep the logits from drifting too far from zero, which can cause
+     unacceptable roundoff errors in bfloat16.
+  2. To encourage the logits to be normalized log-probabilities.
+  Args:
+    logits: [batch, length, num_classes] float array.
+    targets: categorical one-hot targets [batch, length, num_classes] float
+      array.
+    z_loss: coefficient for auxilliary z-loss loss term.
+  Returns:
+    tuple with the total loss and the z_loss, both
+    float arrays with shape [batch, length].
+  """
+  logits_sum = jax.scipy.special.logsumexp(logits, axis=-1, keepdims=True)
+  log_softmax = logits - logits_sum
+  loss = -jnp.sum(targets * log_softmax, axis=-1)
+  # Add auxilliary z-loss term.
+  log_z = jnp.squeeze(logits_sum, axis=-1)
+  total_z_loss = z_loss * jax.lax.square(log_z)
+  loss += total_z_loss
+  return loss, total_z_loss
+
+
+def _cross_entropy_with_logits_fwd(
+    logits: jnp.ndarray,
+    targets: jnp.ndarray,
+    z_loss: float = 0.0
+) -> Tuple[Tuple[jnp.ndarray, jnp.ndarray],
+           Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray,
+                 jnp.ndarray, jnp.ndarray, jnp.ndarray]]:
+  """Forward-mode of `cross_entropy_with_logits`."""
+  max_logit = logits.max(axis=-1, keepdims=True)
+  shifted = logits - max_logit
+  exp_shifted = jnp.exp(shifted)
+  sum_exp = jnp.sum(exp_shifted, axis=-1, keepdims=True)
+  log_softmax = shifted - jnp.log(sum_exp)
+  loss = -jnp.sum(targets * log_softmax, axis=-1)
+  # Add auxilliary z-loss term.
+  log_z = jnp.squeeze(jnp.log(sum_exp) + max_logit, axis=-1)
+  total_z_loss = z_loss * jax.lax.square(log_z)
+  loss += total_z_loss
+  return (loss, total_z_loss), (logits, targets, z_loss, exp_shifted, sum_exp,  # pytype: disable=bad-return-type  # jax-ndarray
+                                log_softmax, log_z)
+
+
+def _cross_entropy_with_logits_bwd(
+    res: Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray, jnp.ndarray,
+               jnp.ndarray, jnp.ndarray], g: Tuple[jnp.ndarray, jnp.ndarray]
+) -> Tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+  """Backward-mode of `cross_entropy_with_logits`."""
+  g = g[0]  # Ignore z_loss component as that is only used for logging.
+  logits, targets, z_loss, exp_shifted, sum_exp, log_softmax, log_z = res
+  # z-loss term adds the (2 * z_loss * log_z) factor.
+  deriv = (
+      jnp.expand_dims(1 + 2 * z_loss * log_z, -1) * exp_shifted / sum_exp -
+      targets)
+  g_logits = jnp.expand_dims(g, axis=-1) * deriv
+  g_targets = -jnp.expand_dims(g, axis=-1) * log_softmax
+  return (jnp.asarray(g_logits,
+                      logits.dtype), jnp.asarray(g_targets, targets.dtype),
+          jnp.array(0.0))  # sets z-loss coeff gradient to 0
+
+cross_entropy_with_logits.defvjp(_cross_entropy_with_logits_fwd,
+                                 _cross_entropy_with_logits_bwd)

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -37,6 +37,7 @@ from flax.linen import partitioning as nn_partitioning
 import optax
 import os
 import subprocess
+from typing import Tuple
 
 
 def l2norm_pytree(x):
@@ -274,9 +275,6 @@ def create_learning_rate_schedule(config):
     boundaries.append(warmup_steps + cos_steps + constant_zero_steps)
 
   return optax.join_schedules(pieces, boundaries)
-  
-from typing import Tuple, Mapping, Optional, Union
-
 
 
 @jax.custom_vjp
@@ -328,7 +326,7 @@ def _cross_entropy_with_logits_fwd(
   log_z = jnp.squeeze(jnp.log(sum_exp) + max_logit, axis=-1)
   total_z_loss = z_loss * jax.lax.square(log_z)
   loss += total_z_loss
-  return (loss, total_z_loss), (logits, targets, z_loss, exp_shifted, sum_exp,  # pytype: disable=bad-return-type  # jax-ndarray
+  return (loss, total_z_loss), (logits, targets, z_loss, exp_shifted, sum_exp, #pytype: disable=bad-return-type  #jax-ndarray
                                 log_softmax, log_z)
 
 

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -277,6 +277,8 @@ def create_learning_rate_schedule(config):
   return optax.join_schedules(pieces, boundaries)
 
 
+# Cross entropy implementation is taken from original T5X codebase 
+# https://github.com/google-research/t5x/blob/ace831eea1e2742b4299cd1a9af7e4f302038351/t5x/losses.py#L25-L101
 @jax.custom_vjp
 def cross_entropy_with_logits(logits: jnp.ndarray, targets: jnp.ndarray,
                               z_loss: float) -> Tuple[jnp.ndarray, jnp.ndarray]:

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -277,7 +277,7 @@ def create_learning_rate_schedule(config):
   return optax.join_schedules(pieces, boundaries)
 
 
-# Cross entropy implementation is taken from original T5X codebase 
+# Cross entropy implementation is taken from original T5X codebase:
 # https://github.com/google-research/t5x/blob/ace831eea1e2742b4299cd1a9af7e4f302038351/t5x/losses.py#L25-L101
 @jax.custom_vjp
 def cross_entropy_with_logits(logits: jnp.ndarray, targets: jnp.ndarray,

--- a/MaxText/tests/max_utils_test.py
+++ b/MaxText/tests/max_utils_test.py
@@ -39,7 +39,7 @@ class MaxUtilsT5XCrossEntropy(unittest.TestCase):
     logits = jax.random.uniform(key, shape=(48, 2048, 32768),
                                         dtype=jax.numpy.float32)
 
-    # Calculate xent from optax implementation                                    
+    # Calculate xent from optax implementation
     optax_xent = optax.softmax_cross_entropy_with_integer_labels(logits, targets)
 
     # Calculate xent from custom T5X implementation


### PR DESCRIPTION
Merge in @rwitten's T5X cross entropy implementation along with unit test. 

Tested the change on the 128B config on 16 x v5e-256 and it increased TFLOP/s by ~10 TFLOP/s and increased memory by 131.48 MiB.

Tested convergence on the 1B config on 1 x v5e-256 for 3400 steps. The achieved loss is about the same.

new t5x xent: (last_10_losses_mean=2.637)
![image](https://github.com/google/maxtext/assets/31597464/b59d4f0d-af98-452a-a11d-ea061d322b62)
original optax xent: (last_10_losses_mean=2.641)
![image](https://github.com/google/maxtext/assets/31597464/df6291e0-e5b4-4721-aae3-697f5d40ca35)

