### PR TITLE
Allow kueue setup to retry up to 5 times in cluster create

### DIFF
--- a/xpk/xpk.py
+++ b/xpk/xpk.py
@@ -898,7 +898,16 @@ def enable_kueue_crds(args, system) -> int:
   )
   tmp = write_temporary_file(yml_string)
   command = f'kubectl apply -f {str(tmp.file.name)}'
-  return_code = run_command_with_updates(command, 'Applying Kueue CRDs', args)
+  # For kueue setup, we see a timeout error due to previous async steps not
+  # completing. Let's retry and wait a few seconds.
+  retry_limit = 5
+  i = 0
+  return_code = -1
+  while (return_code != 0 and i < retry_limit):
+    time.sleep(5)
+    i += 1
+    xpk_print(f'Try {i}: Applying Kueue CRDs')
+    return_code = run_command_with_updates(command, 'Applying Kueue CRDs', args)
 
   if return_code != 0:
     xpk_print(f'Applying Kueue CRDS returned ERROR {return_code}')

--- a/xpk/xpk.py
+++ b/xpk/xpk.py
@@ -898,8 +898,8 @@ def enable_kueue_crds(args, system) -> int:
   )
   tmp = write_temporary_file(yml_string)
   command = f'kubectl apply -f {str(tmp.file.name)}'
-  # For kueue setup, we see a timeout error due to previous async steps not
-  # completing. Let's retry and wait a few seconds.
+  # For kueue setup, we see a timeout error due to the webhook not
+  # being ready. Let's retry and wait a few seconds.
   retry_limit = 5
   i = 0
   return_code = -1


### PR DESCRIPTION
Two retries == happy.

```
[XPK] Waiting for `Set Kueue On Cluster`, for 8 seconds
service/kueue-webhook-service created
deployment.apps/kueue-controller-manager created
mutatingwebhookconfiguration.admissionregistration.k8s.io/kueue-mutating-webhook-configuration created
validatingwebhookconfiguration.admissionregistration.k8s.io/kueue-validating-webhook-configuration created
[XPK] Task: `Set Kueue On Cluster` terminated with code `0`
[XPK] Enable Kueue CRDs
[XPK] Try 1: Applying Kueue CRDs
[XPK] Task: `Applying Kueue CRDs` is implemented by `kubectl apply -f /tmp/tmp7__i43y_`, streaming output live.
[XPK] Waiting for `Applying Kueue CRDs`, for 0 seconds
[XPK] Waiting for `Applying Kueue CRDs`, for 1 seconds
[XPK] Waiting for `Applying Kueue CRDs`, for 2 seconds
priorityclass.scheduling.k8s.io/verylow created
priorityclass.scheduling.k8s.io/low created
priorityclass.scheduling.k8s.io/medium created
priorityclass.scheduling.k8s.io/high created
[XPK] Waiting for `Applying Kueue CRDs`, for 3 seconds
priorityclass.scheduling.k8s.io/veryhigh created
Error from server (InternalError): error when creating "/tmp/tmp7__i43y_": Internal error occurred: failed calling webhook "mresourceflavor.kb.io": failed to call webhook: Post "https://kueue-webhook-service.kueue-system.svc:443/mutate-kueue-x-k8s-io-v1beta1-resourceflavor?timeout=10s": no endpoints available for service "kueue-webhook-service"
Error from server (InternalError): error when creating "/tmp/tmp7__i43y_": Internal error occurred: failed calling webhook "mclusterqueue.kb.io": failed to call webhook: Post "https://kueue-webhook-service.kueue-system.svc:443/mutate-kueue-x-k8s-io-v1beta1-clusterqueue?timeout=10s": no endpoints available for service "kueue-webhook-service"
Error from server (InternalError): error when creating "/tmp/tmp7__i43y_": Internal error occurred: failed calling webhook "vlocalqueue.kb.io": failed to call webhook: Post "https://kueue-webhook-service.kueue-system.svc:443/validate-kueue-x-k8s-io-v1beta1-localqueue?timeout=10s": no endpoints available for service "kueue-webhook-service"
[XPK] Task: `Applying Kueue CRDs` terminated with code `1`
[XPK] Try 2: Applying Kueue CRDs
[XPK] Task: `Applying Kueue CRDs` is implemented by `kubectl apply -f /tmp/tmp7__i43y_`, streaming output live.
[XPK] Waiting for `Applying Kueue CRDs`, for 0 seconds
[XPK] Waiting for `Applying Kueue CRDs`, for 1 seconds
resourceflavor.kueue.x-k8s.io/1xv5litepod-16 created
clusterqueue.kueue.x-k8s.io/cluster-queue created
localqueue.kueue.x-k8s.io/multislice-queue created
priorityclass.scheduling.k8s.io/verylow configured
[XPK] Waiting for `Applying Kueue CRDs`, for 2 seconds
priorityclass.scheduling.k8s.io/low configured
priorityclass.scheduling.k8s.io/medium configured
priorityclass.scheduling.k8s.io/high configured
priorityclass.scheduling.k8s.io/veryhigh configured
[XPK] Task: `Applying Kueue CRDs` terminated with code `0`
[XPK] GKE commands done! TPUs are created.
[XPK] See your GKE Cluster here:
[XPK] Exiting XPK cleanly
```