### PR TITLE
Correctly error if the project name or zone name is unset

### DIFF
--- a/multihost_job.py
+++ b/multihost_job.py
@@ -51,14 +51,14 @@ import shutil
 def get_project():
   completed_command = subprocess.run(["gcloud", "config", "get", "project"], check=True, capture_output=True)
   project_outputs = completed_command.stdout.decode().strip().split('\n')
-  if len(project_outputs) < 1:
+  if len(project_outputs) < 1 or project_outputs[-1]=='':
     sys.exit("You must specify the project in the PROJECT flag or set it with 'gcloud config set project <project>'")
   return project_outputs[-1] # The project name lives on the last line of the output
 
 def get_zone():
   completed_command = subprocess.run(["gcloud", "config", "get", "compute/zone"], check=True, capture_output=True)
   zone_outputs = completed_command.stdout.decode().strip().split('\n')
-  if len(zone_outputs) < 1:
+  if len(zone_outputs) < 1 or zone_outputs[-1]=='':
     sys.exit("You must specify the zone in the ZONE flag or set it with 'gcloud config set compute/zone <zone>'")
   return zone_outputs[-1] # The zone name lives on the last line of the output
 

--- a/xpk/xpk.py
+++ b/xpk/xpk.py
@@ -577,7 +577,7 @@ def get_project():
       ['gcloud', 'config', 'get', 'project'], check=True, capture_output=True
   )
   project_outputs = completed_command.stdout.decode().strip().split('\n')
-  if len(project_outputs) < 1:
+  if len(project_outputs) < 1 or project_outputs[-1] == '':
     sys.exit(
         'You must specify the project in the project flag or set it with'
         " 'gcloud config set project <project>'"
@@ -599,7 +599,7 @@ def get_zone():
       capture_output=True,
   )
   zone_outputs = completed_command.stdout.decode().strip().split('\n')
-  if len(zone_outputs) < 1:
+  if len(zone_outputs) < 1 or zone_outputs[-1] == '':
     sys.exit(
         "You must specify the zone in the zone flag or set it with 'gcloud"
         " config set compute/zone <zone>'"


### PR DESCRIPTION
Previously the error would look confusion instead of directly exiting. Multihost_runner.py already contains these fixes.