### PR TITLE
add ici_tensor_parallelism=4 to test_decode

### DIFF
--- a/end_to_end/test_decode.sh
+++ b/end_to_end/test_decode.sh
@@ -17,6 +17,7 @@ fi
 #Train
 python3 MaxText/decode.py MaxText/configs/base.yml run_name=$RUN_NAME\
     steps=50 enable_checkpointing=False metrics_file='metrics.txt'\
-    base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH
+    base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH\
+    ici_tensor_parallelism=4
 
 python3 end_to_end/eval_assert.py metrics_average metrics.txt $NUM_TOKEN_THRESHOLD num_tokens


### PR DESCRIPTION
This change is to fix the dimension issue in XLML test which was earlier seen in unit tests.  https://pantheon.corp.google.com/kubernetes/job/us-central2/xl-ml-test-1vm-us-central2/automated/mp-jax-nightly-maxtext-decode-func-v4-8-1-slices-6zhfz/logs?project=cloud-tpu-multipod-dev&mods=allow_workbench_image_override&e=13803378
