### PR TITLE
[xpk] Support base-docker-image and script-dir

### DIFF
--- a/xpk/README.md
+++ b/xpk/README.md
@@ -143,26 +143,23 @@ cleanup with a `Cluster Delete`.
 
 # How to add docker images to a xpk workload
 
-The default behavior is that the local running directory will be built into
-a docker image by xpk and those files are accessable by `xpk workload create`.
-See below for the two ways that xpk supports configuring docker images for the
-workload. Do not mix arguments from these two ways like `--base-docker-image`
-and `--docker-image` in the same command.
+The default behavior is `xpk workload create` will layer the local directory (`--script-dir`) into
+the base docker image (`--base-docker-image`) and run the workload command.
+If you don't want this layering behavior, you can directly use `--docker-image`. Do not mix arguments from the two flows in the same command.
 
 ## Recommended / Default Docker Flow: `--base-docker-image` and `--script-dir`
-Pull in a local directory with scripts or files interested in running in
-`xpk workload create`.
+This flow pulls the `--script-dir` into the `--base-docker-image` and runs the new docker image.
 
-* Below arguments are optional since by default, xpk will pull the local
-  directory with a default base docker image.
+* The below arguments are optional by default. xpk will pull the local
+  directory with a generic base docker image.
 
-  `--base-docker-image` to set the base image that xpk will start with.
+  - `--base-docker-image` sets the base image that xpk will start with.
 
-  `--script-dir` to set which directory to pull into the image.
+  - `--script-dir` sets which directory to pull into the image. This defaults to the current working directory.
 
-  See `python3 xpk/xpk.py workload create --help` for more.
+  See `python3 xpk/xpk.py workload create --help` for more info.
 
-* Example with defaults which pulled the local directory into the base image:
+* Example with defaults which pulls the local directory into the base image:
   ```shell
   echo -e '#!/bin/bash \n echo "Hello world from a test script!"' > test.sh
   python3 xpk/xpk.py workload create --cluster xpk-test \

--- a/xpk/README.md
+++ b/xpk/README.md
@@ -157,21 +157,30 @@ Pull in a local directory with scripts or files interested in running in
 * `--script-dir` to set which directory to pull into the image.
 * See `python3 xpk/xpk.py workload create --help` for more.
 
-Example with defaults which pulled the local directory into the base image:
-```shell
-echo -e '#!/bin/bash \n echo "Hello world from a test script!"' > test.sh
-# --script-dir is set by default to the current working directory.
-python3 xpk/xpk.py workload create --cluster xpk-test \
---workload xpk-test-workload-base-image --command "bash test.sh" \
---tpu-type=v5litepod-16 --num-slices=1 --base-docker-image=python:3.10
-```
+* Example with defaults which pulled the local directory into the base image:
+  ```shell
+  echo -e '#!/bin/bash \n echo "Hello world from a test script!"' > test.sh
+  # --script-dir is set by default to the current working directory.
+  python3 xpk/xpk.py workload create --cluster xpk-test \
+  --workload xpk-test-workload-base-image --command "bash test.sh" \
+  --tpu-type=v5litepod-16 --num-slices=1 --base-docker-image=python:3.10
+  ```
+
+* Recommended Flow For Normal Sized Jobs (fewer than 10k accelerators):
+  ```shell
+  python3 xpk/xpk.py workload create --cluster xpk-test \
+  --workload xpk-test-workload-base-image --command "bash custom_script.sh" \
+  --base-docker-image=gcr.io/your_dependencies_docker_image \
+  --script-dir=/custom_dir/
+  --tpu-type=v5litepod-16 --num-slices=1
+  ```
 
 ## Optional Direct Docker Image Configuration: `--docker-image`
 If a user wants to directly set the docker image used and not layer in the
 current working directory, set `--docker-image` to the image to be use in the
 workload.
 
-* Recommended Flow For Normal Sized Jobs (fewer than 10k accelerators)
+* Running with `--docker-image`:
   ```shell
   python3 xpk/xpk.py workload create --cluster xpk-test \
   --workload xpk-test-workload-base-image --command "bash test.sh" \
@@ -197,13 +206,6 @@ feedback.
 * Workload create accepts a --env-file flag to allow specifying the container's
 environment from a file. Usage is the same as Docker's
 [--env-file flag](https://docs.docker.com/engine/reference/commandline/run/#env)
-
-* Access stable fleet TPU machines by adding `--host-maintenance-interval=PERIODIC`
-    ```shell
-    python3 xpk/xpk.py cluster create \
-    --cluster xpk-test --tpu-type=v5litepod-16 \
-    --num-slices=4 --host-maintenance-interval=PERIODIC
-    ```
 
 
 # Troubleshooting

--- a/xpk/README.md
+++ b/xpk/README.md
@@ -153,17 +153,21 @@ and `--docker-image` in the same command.
 Pull in a local directory with scripts or files interested in running in
 `xpk workload create`.
 
-* `--base-docker-image` to set the base image that xpk will start with.
-* `--script-dir` to set which directory to pull into the image.
-* See `python3 xpk/xpk.py workload create --help` for more.
+* Below arguments are optional since by default, xpk will pull the local
+  directory with a default base docker image.
+
+  `--base-docker-image` to set the base image that xpk will start with.
+
+  `--script-dir` to set which directory to pull into the image.
+
+  See `python3 xpk/xpk.py workload create --help` for more.
 
 * Example with defaults which pulled the local directory into the base image:
   ```shell
   echo -e '#!/bin/bash \n echo "Hello world from a test script!"' > test.sh
-  # --script-dir is set by default to the current working directory.
   python3 xpk/xpk.py workload create --cluster xpk-test \
   --workload xpk-test-workload-base-image --command "bash test.sh" \
-  --tpu-type=v5litepod-16 --num-slices=1 --base-docker-image=python:3.10
+  --tpu-type=v5litepod-16 --num-slices=1
   ```
 
 * Recommended Flow For Normal Sized Jobs (fewer than 10k accelerators):
@@ -171,7 +175,6 @@ Pull in a local directory with scripts or files interested in running in
   python3 xpk/xpk.py workload create --cluster xpk-test \
   --workload xpk-test-workload-base-image --command "bash custom_script.sh" \
   --base-docker-image=gcr.io/your_dependencies_docker_image \
-  --script-dir=/custom_dir/
   --tpu-type=v5litepod-16 --num-slices=1
   ```
 

--- a/xpk/Run_MaxText.md
+++ b/xpk/Run_MaxText.md
@@ -27,11 +27,11 @@ This document focusses on steps required to setup XPK on TPU VM and assumes you 
     Kubernetes Engine Admin
 
 * gcloud is installed on TPUVMs using the snap distribution package. Install kubectl using snap
-```
+```shell
 sudo snap install kubectl --classic
 ```
 * Install `gke-gcloud-auth-plugin`
-```
+```shell
 echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
@@ -42,44 +42,47 @@ sudo apt update && sudo apt-get install google-cloud-sdk-gke-gcloud-auth-plugin
 
 ## Build Docker Image for Maxtext
 
-* Git clone maxtext locally
+1. Git clone maxtext locally
 
-    ```
-    git clone  https://github.com/google/maxtext.git
+    ```shell
+    git clone https://github.com/google/maxtext.git
     cd maxtext
     ```
-* Build local Maxtext docker image
+2. Build local Maxtext docker image
 
     This only needs to be rerun when you want to change your dependencies. This image may expire which would require you to rerun the below command
 
-    ```
+    ```shell
     # Default will pick stable versions of dependencies
     bash docker_build_dependency_image.sh
     ```
-* Upload image to your gcp project
+3. Upload image to your gcp project
 
     This copies your working directory to the cloud and layers it on top of the dependency image. The first time you do this for a given dependency_image it will take a couple minutes. Subsequent times take less than a second!
 
-    ```
+    ```shell
     gcloud config set project $PROJECT_ID
     bash docker_upload_runner.sh CLOUD_IMAGE_NAME=${USER}_runner
     ```
+4. After uploading the custom image once, xpk can handle updates to the working directory when running `xpk workload create`
 
-## Using XPK to run Maxtext
+    __Using XPK to upload image to your gcp project and run Maxtext__
 
-    gcloud config set project $PROJECT_ID
-    gcloud config set compute/zone $ZONE
+      ```shell
+      gcloud config set project $PROJECT_ID
+      gcloud config set compute/zone $ZONE
 
-    # Make sure you are in the maxtext github root directory when running this command
+      # Make sure you are in the maxtext github root directory when running this command
 
-    python3 xpk/xpk.py workload create \
-    --cluster ${CLUSTER_NAME} \
-    --docker-image gcr.io/${PROJECT_ID}/${USER}_runner \
-    --workload ${USER}-first-job \
-    --tpu-type=v5litepod-256 \
-    --num-slices=1  \
-    --command "python3 MaxText/train.py MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_DIR} dataset_path=${DATASET_PATH} steps=100 per_device_batch_size=1"
-    
+      python3 xpk/xpk.py workload create \
+      --cluster ${CLUSTER_NAME} \
+      --base-docker-image gcr.io/${PROJECT_ID}/${USER}_runner \
+      --workload ${USER}-first-job \
+      --tpu-type=v5litepod-256 \
+      --num-slices=1  \
+      --command "python3 MaxText/train.py MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_DIR} dataset_path=${DATASET_PATH} steps=100 per_device_batch_size=1"
+      ```
+
 
 
 

--- a/xpk/xpk.py
+++ b/xpk/xpk.py
@@ -1273,9 +1273,10 @@ def build_docker_image_from_base_image(args, verbose=True) -> tuple[int, str]:
     xpk_exit(1)
 
   # Pick a randomly generated `tag_length` character docker tag.
-  tag_length = 8
-  tag_name = ''.join(random.choices(string.ascii_lowercase, k=tag_length))
-
+  tag_length = 4
+  tag_random_prefix = ''.join(random.choices(string.ascii_lowercase, k=tag_length))
+  tag_datetime = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+  tag_name = f'{tag_random_prefix}-{tag_datetime}'
   cloud_docker_image = f'gcr.io/{args.project}/{docker_name}:{tag_name}'
   xpk_print(f'Adding Docker Image: {cloud_docker_image} to {args.project}')
 

--- a/xpk/xpk.py
+++ b/xpk/xpk.py
@@ -43,7 +43,9 @@ Next Steps:
 import argparse
 import datetime
 import os
+import random
 import re
+import string
 import subprocess
 import sys
 import tempfile
@@ -52,6 +54,9 @@ from dataclasses import dataclass
 
 
 ################### Internally used constants ##############
+
+default_docker_image = 'python:3.10'
+default_script_dir = os.getcwd()
 
 workload_create_yaml = """apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
@@ -84,7 +89,7 @@ spec:
               dnsPolicy: ClusterFirstWithHostNet
               containers:
               - name: {args.docker_name}
-                image: {args.docker_image}
+                image: {docker_image}
                 env: {args.env}
                 ports:
                 - containerPort: 8471
@@ -107,6 +112,17 @@ metadata:
   name: {args.workload}
   annotations:
     alpha.jobset.sigs.k8s.io/exclusive-topology: cloud.google.com/gke-nodepool # 1:1 job replica to node pool assignment
+"""
+
+script_dir_dockerfile = """FROM {base_docker_image}
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy all files from local workspace into docker container
+COPY . .
+
+WORKDIR /app
 """
 
 cluster_set_crd_yaml = """apiVersion: kueue.x-k8s.io/v1beta1
@@ -1187,17 +1203,17 @@ def cluster_list(args) -> int:
   return 0
 
 
-def validate_docker_image(args) -> int:
+def validate_docker_image(docker_image, args) -> int:
   """Validates that the user provided docker image exists in your project.
 
   Args:
+    docker_image: The docker image to verify.
     args: user provided arguments for running the command.
 
   Returns:
     0 if successful and 1 otherwise.
   """
 
-  docker_image = args.docker_image
   project = args.project
 
   if docker_image.find('gcr.io') == -1:
@@ -1217,6 +1233,84 @@ def validate_docker_image(args) -> int:
     return return_code
   else:
     return 0
+
+
+def build_docker_image_from_base_image(args, verbose=True) -> tuple[int, str]:
+  """Adds script dir to the base docker image and uploads the image.
+
+  Args:
+    args: user provided arguments for running the command.
+
+  Returns:
+    Tuple of:
+      0 if successful and 1 otherwise.
+      Name of the Docker image created.
+  """
+
+  # Pick a name for the docker image.
+  docker_image_prefix = os.getenv('USER', 'unknown')
+  docker_name = f'{docker_image_prefix}-runner'
+
+  docker_file = script_dir_dockerfile.format(
+      base_docker_image=args.base_docker_image,
+  )
+  tmp = write_temporary_file(docker_file)
+  docker_build_command = (
+      f'docker build -f {str(tmp.file.name)} -t {docker_name}'
+      f' {args.script_dir}'
+  )
+  xpk_print(f'Building {args.script_dir} into docker image.')
+  return_code = run_command_with_updates(
+      docker_build_command, 'Building script_dir into docker image', args,
+      verbose=verbose
+  )
+  if return_code != 0:
+    xpk_print(
+        'Failed to add script_dir to docker image, check the base docker image.'
+        f' You should be able to navigate to the URL {args.base_docker_image}'
+        f' in {args.project}.'
+    )
+    xpk_exit(1)
+
+  # Pick a randomly generated `tag_length` character docker tag.
+  tag_length = 8
+  tag_name = ''.join(random.choices(string.ascii_lowercase, k=tag_length))
+
+  cloud_docker_image = f'gcr.io/{args.project}/{docker_name}:{tag_name}'
+  xpk_print(f'Adding Docker Image: {cloud_docker_image} to {args.project}')
+
+  # Tag the docker image.
+  tag_docker_image_command = (
+      f'docker tag {docker_name} {cloud_docker_image}'
+  )
+  return_code = run_command_with_updates(
+      tag_docker_image_command, 'Tag Docker Image', args,
+      verbose=verbose
+  )
+  if return_code != 0:
+    xpk_print(
+        f'Failed to tag docker image with tag: {tag_name}.'
+        f' You should be able to navigate to the URL {cloud_docker_image} in'
+        f' {args.project}.'
+    )
+    xpk_exit(1)
+
+  # Upload image to Artifact Registry.
+  upload_docker_image_command = (
+      f'docker push {cloud_docker_image}'
+  )
+  return_code = run_command_with_updates(
+      upload_docker_image_command, 'Upload Docker Image', args,
+      verbose=verbose
+  )
+  if return_code != 0:
+    xpk_print(
+        f'Failed to upload docker image.'
+        f' You should be able to navigate to the URL {cloud_docker_image} in'
+        f' {args.project}.'
+    )
+    xpk_exit(1)
+  return return_code, cloud_docker_image
 
 
 def check_if_workload_exists(args) -> bool:
@@ -1251,6 +1345,68 @@ def check_if_workload_exists(args) -> bool:
   return False
 
 
+def use_base_docker_image_or_docker_image(args) -> bool:
+  """Checks for correct docker image arguments.
+
+  Args:
+    args: user provided arguments for running the command.
+
+  Returns:
+    True if intented to use base docker image, False to use docker image.
+  """
+  use_base_docker_image = True
+  # Check if (base_docker_image and script_dir) or (docker_image) is set.
+  if args.docker_image is not None:
+    if args.script_dir is not default_script_dir:
+      xpk_print(
+          '`--script-dir` and --docker-image can not be used together. Please'
+          ' see `--help` command for more details.'
+      )
+      xpk_exit(1)
+    if args.base_docker_image is not default_docker_image:
+      xpk_print(
+          '`--base-docker-image` and --docker-image can not be used together.'
+          ' Please see `--help` command for more details.'
+      )
+      xpk_exit(1)
+    use_base_docker_image = False
+  return use_base_docker_image
+
+
+def setup_docker_image(args) -> tuple[int, str]:
+  """Does steps to verify docker args, check image, and build image (if asked).
+
+  Args:
+    args: user provided arguments for running the command.
+
+  Returns:
+    tuple:
+      0 if successful and 1 otherwise.
+      Name of the docker image to use.
+  """
+  use_base_docker_image = use_base_docker_image_or_docker_image(args)
+
+  docker_image = args.base_docker_image
+  if use_base_docker_image:
+    validate_docker_image_code = validate_docker_image(
+        docker_image, args
+    )
+    if validate_docker_image_code != 0:
+      xpk_exit(validate_docker_image_code)
+    build_docker_image_code, docker_image = build_docker_image_from_base_image(args)
+    if build_docker_image_code != 0:
+      xpk_exit(build_docker_image_code)
+  else:
+    docker_image = args.docker_image
+    validate_docker_image_code = validate_docker_image(
+        args.docker_image, args
+    )
+    if validate_docker_image_code != 0:
+      xpk_exit(validate_docker_image_code)
+
+  return 0, docker_image
+
+
 def workload_create(args) -> int:
   """Run jobset apply command for a file.
 
@@ -1278,12 +1434,12 @@ def workload_create(args) -> int:
   xpk_print('Starting workload create', flush=True)
   system = UserFacingNameToSystemCharacteristics[args.tpu_type]
 
-  validate_docker_image_code = validate_docker_image(args)
-  if validate_docker_image_code != 0:
-    xpk_exit(validate_docker_image_code)
+  setup_docker_image_code, docker_image = setup_docker_image(args)
+  if setup_docker_image_code != 0:
+    xpk_exit(setup_docker_image_code)
 
   add_env_config(args)
-  yml_string = workload_create_yaml.format(args=args, system=system)
+  yml_string = workload_create_yaml.format(args=args, system=system, docker_image=docker_image)
   tmp = write_temporary_file(yml_string)
   command = f'kubectl apply -f {str(tmp.file.name)}'
 
@@ -1420,6 +1576,14 @@ def workload_name_type(value, pat=re.compile(r'[a-z]([-a-z0-9]*[a-z0-9])?')):
         'Workload name must be less than 40 characters and match the pattern'
         f' `{pat.pattern}`'
         f' Name is currently {value}'
+    )
+  return value
+
+
+def directory_path_type(value):
+  if not os.path.isdir(value):
+    raise argparse.ArgumentTypeError(
+      f'Directory path is invalid. User provided path was {value}'
     )
   return value
 
@@ -1668,60 +1832,43 @@ workload_subcommands = workload_parser.add_subparsers(
 workload_create_parser = workload_subcommands.add_parser(
     'create', help='Create a new job.'
 )
-workload_custom_arguments = workload_create_parser.add_argument_group(
-    'Workload Built-in Arguments', 'Configure xpk to create a Workload for you.'
+workload_create_parser_required_arguments = (
+    workload_create_parser.add_argument_group(
+        'Workload Built-in Arguments',
+        'Configure xpk to create a Workload for you.'
+    )
 )
-
 workload_create_parser_optional_arguments = (
     workload_create_parser.add_argument_group(
         'Optional Arguments', 'Arguments optional for `job create`.'
     )
 )
-### Workload arguments
-workload_custom_arguments.add_argument(
+workload_base_docker_image_arguments = (
+    workload_create_parser.add_argument_group(
+        'Base Docker Image Arguments',
+        'User supplies a base image or by default the image is set by xpk.'
+        ' Xpk will add the `script_dir` to the base image creating an anonymous'
+        ' docker image. These arguments are exclusive to `--docker-image`.'
+    )
+)
+workload_docker_image_arguments = (
+    workload_create_parser.add_argument_group(
+        'Docker Image Arguments',
+        '`--base-docker-image` is used by default. Set this argument if the'
+        ' user wants the docker image to be used directly by the xpk workload.'
+    )
+)
+
+
+### Workload required arguments
+workload_create_parser_required_arguments.add_argument(
     '--workload',
     type=workload_name_type,
     default=None,
     help='The name of the workload to run.',
     required=True,
 )
-workload_custom_arguments.add_argument(
-    '--docker-name',
-    type=str,
-    default='jax-tpu',
-    help=(
-        'The name of the docker-image to use, default and typically `jax-tpu`.'
-    ),
-)
-workload_custom_arguments.add_argument(
-    '--docker-image',
-    type=str,
-    default='python:3.10',
-    help=(
-        'The version of the docker-image to use, default `python:3.10`. If using'
-        ' a custom docker image it is typically addressed as'
-        ' gcr.io/${PROJECT}/${NAME}:latest'
-    ),
-)
-
-workload_custom_arguments.add_argument(
-    '--num-slices',
-    type=str,
-    default=1,
-    help='The number of slices to use, default=1.',
-)
-workload_custom_arguments.add_argument(
-    '--env-file',
-    type=str,
-    default=None,
-    help=(
-        'Environment file to be applied to the container.  This file should '
-        'use the syntax <variable>=value (which sets the variable to the given '
-        'value) or <variable> (which takes the value from the local '
-        'environment), and # for comments.'
-    ),
-)
-workload_custom_arguments.add_argument(
+workload_create_parser_required_arguments.add_argument(
     '--command',
     type=str,
     default=None,
@@ -1733,14 +1880,14 @@ workload_custom_arguments.add_argument(
     ),
     required=True,
 )
-workload_custom_arguments.add_argument(
+workload_create_parser_required_arguments.add_argument(
     '--tpu-type',
     type=str,
     default=None,
     help='The tpu type to use, v5litepod-16, etc.',
     required=True,
 )
-workload_custom_arguments.add_argument(
+workload_create_parser_required_arguments.add_argument(
     '--cluster',
     type=str,
     default=None,
@@ -1748,10 +1895,66 @@ workload_custom_arguments.add_argument(
     required=True,
 )
 
-### Optional Arguments
-add_shared_arguments(workload_custom_arguments)
+### Workload Optional Arguments
+add_shared_arguments(workload_create_parser_optional_arguments)
 
-workload_custom_arguments.add_argument(
+workload_create_parser_optional_arguments.add_argument(
+    '--docker-name',
+    type=str,
+    default='jax-tpu',
+    help=(
+        'The name of the docker-image to use, default and typically `jax-tpu`.'
+    ),
+)
+workload_docker_image_arguments.add_argument(
+    '--docker-image',
+    type=str,
+    help=(
+        'The version of the docker-image to use. By default, '
+        ' `--base-docker-image` is used. Set this argument if the user wants'
+        ' the docker image to be used directly by the xpk workload.'
+        ' a custom docker image it is typically addressed as'
+        ' gcr.io/${PROJECT}/${NAME}:latest. This docker image will be used'
+        ' directly by the xpk workload.'
+    ),
+)
+workload_base_docker_image_arguments.add_argument(
+    '--base-docker-image',
+    type=str,
+    default=default_docker_image,
+    help=(
+        f'The base docker-image to use, default {default_docker_image}. If'
+        ' using a custom docker image it is typically addressed as'
+        ' gcr.io/${PROJECT}/${NAME}:latest. This docker image will be used as a'
+        ' base image by default and the `--script-dir` by default'
+        ' will be added to the image.'
+    ),
+)
+workload_base_docker_image_arguments.add_argument(
+    '--script-dir',
+     type=directory_path_type,
+     default=default_script_dir,
+    help='The local location of the directory to copy to the docker image and'
+        ' run the main command from. Defaults to current working directory.'
+)
+workload_create_parser_optional_arguments.add_argument(
+    '--num-slices',
+    type=str,
+    default=1,
+    help='The number of slices to use, default=1.',
+)
+workload_create_parser_optional_arguments.add_argument(
+    '--env-file',
+    type=str,
+    default=None,
+    help=(
+        'Environment file to be applied to the container.  This file should '
+        'use the syntax <variable>=value (which sets the variable to the given '
+        'value) or <variable> (which takes the value from the local '
+        'environment), and # for comments.'
+    ),
+)
+workload_create_parser_optional_arguments.add_argument(
     '--priority',
     type=str,
     default='medium',
@@ -1760,8 +1963,7 @@ workload_custom_arguments.add_argument(
         ' Defaults to `medium`.'
     ),
 )
-
-workload_custom_arguments.add_argument(
+workload_create_parser_optional_arguments.add_argument(
     '--scheduler',
     type=str,
     default='default-scheduler',
@@ -1771,9 +1973,7 @@ workload_custom_arguments.add_argument(
         'want to use `gke.io/high-throughput-scheduler`.'
     ),
 )
-
-
-workload_custom_arguments.add_argument(
+workload_create_parser_optional_arguments.add_argument(
     '--max-restarts',
     type=str,
     default='0',


### PR DESCRIPTION
- Adds support to build local files into the docker image
- Adds readme example for how to do this
- Continues to support docker-image for not building local files into the image.

Tested
- Ran examples with local file changes
- Verified that directory path has to be valid
- Verified that invalid group of arguments don't work