### PR TITLE
[xpk] Check the version of python before running xpk

### DIFF
--- a/xpk/xpk.py
+++ b/xpk/xpk.py
@@ -52,6 +52,23 @@ import tempfile
 import time
 from dataclasses import dataclass
 
+################### Compatibility Check ###################
+# Check that the user runs the below version or greater.
+
+major_version_supported = 3
+minor_version_supported = 10
+
+user_major_version = sys.version_info[0]
+user_minor_version = sys.version_info[1]
+if (
+    user_major_version < major_version_supported
+    or user_minor_version < minor_version_supported
+):
+  raise RuntimeError('xpk must be run with Python'
+      f' {major_version_supported}.{minor_version_supported} or greater.'
+      f' User currently is running {user_major_version}.{user_minor_version}'
+  )
+
 
 ################### Internally used constants ##############
 


### PR DESCRIPTION
If python version is < 3.10, return error message.

Tested: Yes.