### PR TITLE
Add --quiet flag to node-pools list

### DIFF
--- a/xpk/xpk.py
+++ b/xpk/xpk.py
@@ -1169,7 +1169,7 @@ def cluster_describe(args) -> int:
 
   command = (
       f'gcloud container node-pools  list --cluster {args.cluster} '
-      f'--project={args.project} --region={zone_to_region(args.zone)}'
+      f'--project={args.project} --region={zone_to_region(args.zone)} --quiet'
   )
 
   return_code = run_command_with_updates(command, 'Cluster nodepool list', args)

--- a/xpk/xpk.py
+++ b/xpk/xpk.py
@@ -1168,6 +1168,7 @@ def cluster_describe(args) -> int:
     xpk_exit(set_cluster_command_code)
 
   command = (
+      f'gcloud components update --quiet && '
       f'gcloud container node-pools  list --cluster {args.cluster} '
       f'--project={args.project} --region={zone_to_region(args.zone)} --quiet'
   )


### PR DESCRIPTION
Add --quiet flag to accept default answers for all prompts for the `gcloud container node-pools  list --cluster` command