### PR TITLE
DCN parallelism for multislice only

### DIFF
--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -130,10 +130,10 @@ def create_device_mesh(config, logging=True):
   ici_parallelism = [config.ici_data_parallelism, config.ici_fsdp_parallelism, config.ici_tensor_parallelism]
 
   # Find possible unspecified parallelisms
-  dcn_parallelism = fill_unspecified_mesh_axes(dcn_parallelism, num_slices, 'DCN')
   ici_parallelism = fill_unspecified_mesh_axes(ici_parallelism, num_devices_per_slice, 'ICI')
 
   if multi_slice_env:
+    dcn_parallelism = fill_unspecified_mesh_axes(dcn_parallelism, num_slices, 'DCN')
     mesh = mesh_utils.create_hybrid_device_mesh(ici_parallelism, dcn_parallelism)
   else:
     mesh = mesh_utils.create_device_mesh(ici_parallelism)


### PR DESCRIPTION
Only attempt to fill unspecified axes of DCN parallelism when training with multi-slice. Otherwise some assertions get raised when building a non-hybrid device mesh and you end up feeling confused and insecure.