### PR TITLE
Add a workflow to auto add 'pull ready' label

### DIFF
--- a/.github/workflows/AddLabel.yml
+++ b/.github/workflows/AddLabel.yml
@@ -1,0 +1,81 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Add Label
+
+on:
+  workflow_call:
+  pull_request_review:
+  workflow_dispatch:
+
+jobs:
+  AddPullReady:
+    if: github.ref != 'refs/heads/main'
+    permissions:
+      checks: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            const owner = "google"
+            const repo = "maxtext"
+            const pull_number = context.payload.pull_request.number
+
+            const reviews = await github.rest.pulls.listReviews({
+              owner,
+              repo,
+              pull_number,
+            })
+            for (const review of reviews.data) {
+              if (review.state !== "APPROVED" && review.state !== "COMMENTED") {
+                console.log("Not adding pull ready because the review is requesting a change: ", review.html_url)
+                process.exit()
+              }
+            }
+
+            let allPassed = true
+            const commits = await github.rest.pulls.listCommits({
+              owner,
+              repo,
+              pull_number,
+              per_page: 100,
+            })
+            const ref = commits.data.slice(-1)[0].sha
+            const checkRuns = await github.rest.checks.listForRef({
+              owner,
+              repo,
+              ref,
+            })
+            if (checkRuns.data.check_runs.length === 0) {
+              console.log("Not adding pull ready because no check runs are associated with the last commit: " + ref)
+              process.exit()
+            }
+            for (const checkRun of checkRuns.data.check_runs) {
+              if (checkRun.name.endsWith(context.job)) continue
+              if (checkRun.conclusion !== "success") {
+                console.log("Not adding pull ready because " + checkRun.name + " has not passed yet: checkRun.html_url")
+                process.exit()
+              }
+            }
+            console.log("Adding pull ready label because the PR is approved AND all the check runs have passed")
+            await github.rest.issues.addLabels({
+              issue_number: pull_number,
+              labels: ["pull ready"],
+              owner,
+              repo,
+            })
+            

--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -57,3 +57,10 @@ jobs:
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
         'python3 MaxText/train.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M) base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset int8_training=true steps=2'
+  add_pull_ready:
+    if: github.ref != 'refs/heads/main'
+    permissions:
+      checks: read
+      pull-requests: write
+    needs: build
+    uses: ./.github/workflows/AddLabel.yml


### PR DESCRIPTION
This workflow runs whenever
 - Unit Test workflow completes OR
 - Review is created, edited, or deleted

and adds 'pull ready' label when
 - All of the reviews approve the PR AND
 - All of the workflow associated with the last commit pass.