### PR TITLE
Unpin tensorflow in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ protobuf==3.20.3
 pylint
 pytest
 sentencepiece==0.1.97
-tensorflow==2.13.*
+tensorflow
 tensorflow-datasets
 tensorflow-text
 tensorboardx


### PR DESCRIPTION
Unpin tensorflow in requirements.txt as container size is not much different when using latest TF vs TF 2.13