### PR TITLE
Simplify the mulithost data loading code

### DIFF
--- a/MaxText/input_pipeline.py
+++ b/MaxText/input_pipeline.py
@@ -130,14 +130,6 @@ def preprocessing_pipeline(
       num_parallel_calls=tf.data.AUTOTUNE,
       deterministic=True)
 
-  # Multihost dataloading: sharding and jax.Array prep function
-  dataset_structure = tf.data.experimental.get_structure(dataset)
-  global_data_shape = jax.tree_map(
-      lambda x: P(batch_size, max_length), dataset_structure
-  )
-  data_axes = jax.tree_map(lambda x: P(*data_sharding), dataset_structure)
-
-
   assert (
         batch_size % global_mesh.size == 0
     ), 'Batch size should be divisible number of global devices.'
@@ -156,11 +148,8 @@ def preprocessing_pipeline(
   if prefetch_size:
     dataset = dataset.prefetch(prefetch_size)
 
-  multihost_gen = (
-      multihost_dataloading.get_batch_sharded_data_pipeline(
-          dataset, data_sharding, global_data_shape, global_mesh, data_axes
-      )
-  )
+  multihost_dataloading.get_batch_sharded_data_pipeline(dataset, global_mesh)
+
   # Return multi-host jax.Array prep iterator
   return multihost_gen
 

--- a/MaxText/input_pipeline.py
+++ b/MaxText/input_pipeline.py
@@ -148,7 +148,7 @@ def preprocessing_pipeline(
   if prefetch_size:
     dataset = dataset.prefetch(prefetch_size)
 
-  multihost_dataloading.get_batch_sharded_data_pipeline(dataset, global_mesh)
+  multihost_gen = multihost_dataloading.get_batch_sharded_data_pipeline(dataset, global_mesh)
 
   # Return multi-host jax.Array prep iterator
   return multihost_gen


### PR DESCRIPTION
See if this is an improvement for your purposes. This PR modifies the multihost data put code to infer the global shapes and build `NamedSharding`s lazily at load time. This is cheap because all the relevant quantities are cached by Jax. Unsure if `jax.local_process_count()` is cached, so I'm instead using `len(global_mesh.local_devices)`.

I made this modification to my personal fork because it means I can change up what columns are coming from the data loader without modifying a bunch of stuff in `input_pipeline.py`. 

Tested with the synthetic dataset here on a v4-8 with 
```shell
python MaxText/train.py MaxText/configs/base.yml run_name="mypr" base_output_directory="gs://smoogle" dataset_type=synthetic dataset_path="gs://woozle_wazzle"
```