### PR TITLE
Maximize per_device_batch_size in 1024b config

### DIFF
--- a/MaxText/configs/experimental/1024b.sh
+++ b/MaxText/configs/experimental/1024b.sh
@@ -31,7 +31,7 @@ fi
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
-    steps=20 per_device_batch_size=1 enable_checkpointing=false\
+    steps=20 per_device_batch_size=2 enable_checkpointing=false\
     enable_profiler=false remat_policy=full global_parameter_scale=1024\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=16\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\

--- a/MaxText/configs/experimental/512b.sh
+++ b/MaxText/configs/experimental/512b.sh
@@ -31,8 +31,8 @@ fi
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
-    steps=20 per_device_batch_size=1 enable_checkpointing=false\
-    enable_profiler=false remat_policy=minimal global_parameter_scale=512\
+    steps=20 per_device_batch_size=2 enable_checkpointing=false\
+    enable_profiler=false remat_policy=full global_parameter_scale=512\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=16\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\


### PR DESCRIPTION
As titled, have verified and found MFU increased by maximizing `per_device_batch_size=2` in the test. 

Update:
Maximize MFU by updating per_device_batch_size and remat_policy in 512b config from @raymondzouu 