### PR TITLE
Initialize Jax Distributed System First

### DIFF
--- a/MaxText/checkpointing.py
+++ b/MaxText/checkpointing.py
@@ -18,38 +18,13 @@
 
 from etils import epath
 import jax
-import portpicker
-from jax.experimental import multihost_utils
 from orbax import checkpoint
 from orbax.checkpoint.checkpoint_manager import CheckpointManager, CheckpointManagerOptions, Checkpointer, AsyncCheckpointer
 from orbax.checkpoint import type_handlers
-import socket
 
 import max_logging
 
 from flax.training import train_state
-
-def _multislice_distribute_initialize():
-  """Calls jax.distribute.initialize() with appropriate multislice arguments."""
-
-  def gen_local_ip():
-    hostname = socket.gethostname()
-    return socket.gethostbyname(hostname)
-
-  def gen_local_ip_nums():
-    return [int(num) for num in gen_local_ip().split(':')[-1].split('.')]
-
-  def get_coordinator_ip():
-    local_ip_nums = jax.numpy.array(gen_local_ip_nums())
-    coordinator_ip_nums = multihost_utils.broadcast_one_to_all(local_ip_nums)
-    coordinator_ip_strings = [str(num) for num in list(coordinator_ip_nums)]
-    return '.'.join(coordinator_ip_strings)
-
-  port = multihost_utils.broadcast_one_to_all(jax.numpy.array(portpicker.pick_unused_port()))
-  coordinator_address = get_coordinator_ip() + ':' + str(port)
-  jax.distributed.initialize(coordinator_address=coordinator_address,
-                             num_processes=jax.process_count(),
-                             process_id=jax.process_index())
 
 def create_orbax_checkpoint_manager(
     checkpoint_dir: str,
@@ -64,7 +39,6 @@ def create_orbax_checkpoint_manager(
   max_logging.log("Creating checkpoint manager...")
   p = epath.Path(checkpoint_dir)
   if use_async:
-    _multislice_distribute_initialize()
     checkpointer = AsyncCheckpointer(checkpoint.PyTreeCheckpointHandler())
   else:
     checkpointer = Checkpointer(checkpoint.PyTreeCheckpointHandler())

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -25,7 +25,6 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from jax.experimental import mesh_utils, multihost_utils
-from jax._src.cloud_tpu_init import running_in_cloud_tpu_vm
 
 
 import json
@@ -143,13 +142,12 @@ def initialize_jax_distributed_system():
                               num_processes=jax.process_count(),
                               process_id=jax.process_index())
 
-  if running_in_cloud_tpu_vm:
-    max_logging.log("Attempting to initialize the jax distributed system...")
-    if jax.__version__ >= '0.4.21':
-      jax.distributed.initialize()
-    else:
-      legacy_distribute_initialize()
-    max_logging.log("Jax distributed system initialized!")
+  max_logging.log("Attempting to initialize the jax distributed system...")
+  if jax.__version__ >= '0.4.21':
+    jax.distributed.initialize()
+  else:
+    legacy_distribute_initialize()
+  max_logging.log("Jax distributed system initialized!")
 
 def fill_unspecified_mesh_axes(parallelism_vals, target_product, parallelism_type):
   """Evaluates unspecified DCN/ICI parallelism values"""

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -25,6 +25,7 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from jax.experimental import mesh_utils, multihost_utils
+from jax._src.cloud_tpu_init import running_in_cloud_tpu_vm
 
 
 import json
@@ -142,12 +143,13 @@ def initialize_jax_distributed_system():
                               num_processes=jax.process_count(),
                               process_id=jax.process_index())
 
-  max_logging.log("Attempting to initialize the jax distributed system...")
-  if jax.__version__ >= '0.4.21':
-    jax.distributed.initialize()
-  else:
-    legacy_distribute_initialize()
-  max_logging.log("Jax distributed system initialized!")
+  if running_in_cloud_tpu_vm:
+    max_logging.log("Attempting to initialize the jax distributed system...")
+    if jax.__version__ >= '0.4.21':
+      jax.distributed.initialize()
+    else:
+      legacy_distribute_initialize()
+    max_logging.log("Jax distributed system initialized!")
 
 def fill_unspecified_mesh_axes(parallelism_vals, target_product, parallelism_type):
   """Evaluates unspecified DCN/ICI parallelism values"""

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -25,6 +25,8 @@ import numpy as np
 import jax
 import jax.numpy as jnp
 from jax.experimental import mesh_utils, multihost_utils
+from jax._src.cloud_tpu_init import running_in_cloud_tpu_vm
+
 
 import json
 import flax
@@ -141,12 +143,13 @@ def initialize_jax_distributed_system():
                               num_processes=jax.process_count(),
                               process_id=jax.process_index())
 
-  max_logging.log("Attempting to initialize the jax distributed system...")
-  if jax.__version__ >= '0.4.21':
-    jax.distributed.initialize()
-  else:
-    legacy_distribute_initialize()
-  max_logging.log("Jax distributed system initialized!")
+  if running_in_cloud_tpu_vm:
+    max_logging.log("Attempting to initialize the jax distributed system...")
+    if jax.__version__ >= '0.4.21':
+      jax.distributed.initialize()
+    else:
+      legacy_distribute_initialize()
+    max_logging.log("Jax distributed system initialized!")
 
 def fill_unspecified_mesh_axes(parallelism_vals, target_product, parallelism_type):
   """Evaluates unspecified DCN/ICI parallelism values"""

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -19,6 +19,7 @@ from collections import OrderedDict
 
 import accelerator_to_spec_map
 import math
+import max_utils
 import os
 import sys
 import yaml

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -18,6 +18,7 @@
 from collections import OrderedDict
 
 import accelerator_to_spec_map
+import max_utils
 import math
 import os
 import sys
@@ -35,13 +36,6 @@ def string_to_bool(s: str) -> bool:
   raise ValueError(f"Can't convert {s} to bool")
 
 _yaml_types_to_parser = {str : str, int : int, float : float, bool : string_to_bool}
-
-def validate_attention_type(s: str) -> bool:
-  valid_attention_types = ('mha', 'flash')
-  if s not in valid_attention_types: # currently supported attention
-    raise ValueError(
-      "Invalid attention type was passed. Valid options ", valid_attention_types
-    )
 
 _config = None
 config = None
@@ -93,6 +87,13 @@ class _HyperParameters():
 
   @staticmethod
   def user_init(raw_keys):
+    """ Parse input arguments """
+
+    # We check whether to initialize the jax distributed system here since
+    # it must be initialized before the device backend.
+    if raw_keys["enable_checkpointing"] and raw_keys["async_checkpointing"] and raw_keys["compile_topology_num_slices"]=="":
+      max_utils.initialize_jax_distributed_system()
+
     '''Transformations between the config data and configs used at runtime'''
     raw_keys["dtype"] = jax.numpy.dtype(raw_keys["dtype"])
     if raw_keys["run_name"] == "":
@@ -121,8 +122,6 @@ class _HyperParameters():
     raw_keys['global_batch_size_to_load'], raw_keys['global_batch_size_to_train_on'] = \
       calculate_global_batch_sizes(raw_keys)
 
-    validate_attention_type(raw_keys['attention'])
-
 
 def get_individual_scales(scale):
   '''Choose appropriate scales for individual dimensions based on global scale
@@ -147,9 +146,9 @@ def get_individual_scales(scale):
 
 def calculate_global_batch_sizes(raw_keys):
   """ Calculates target global batch size from target devices and per_device_batch"""
-  per_device_batch_size = raw_keys['per_device_batch_size']
+  per_device_batch_size = int(raw_keys['per_device_batch_size'])
   num_devices = get_num_target_devices(raw_keys)
-  if per_device_batch_size < 1.0:
+  if per_device_batch_size < 1:
     # For per_device_batch_size<1, we load the data as if per_device_batch_size=1
     global_batch_size_to_load = num_devices
   else:

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -94,6 +94,12 @@ class _HyperParameters():
   @staticmethod
   def user_init(raw_keys):
     '''Transformations between the config data and configs used at runtime'''
+
+    # We initialize the jax distributed system here because it must be done before device backend is initialized.
+    print(f'{raw_keys["compile_num_slices"]}')
+    if raw_keys["enable_checkpointing"] and raw_keys["async_checkpointing"] and raw_keys["compile_num_slices"] is None:
+      max_utils.initialize_jax_distributed_system()
+
     raw_keys["dtype"] = jax.numpy.dtype(raw_keys["dtype"])
     if raw_keys["run_name"] == "":
       raw_keys["run_name"] = os.environ.get("JOBSET_NAME") #using XPK default

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -97,7 +97,7 @@ class _HyperParameters():
     '''Transformations between the config data and configs used at runtime'''
 
     # We initialize the jax distributed system here because it must be done before device backend is initialized.
-    print(f'{raw_keys["compile_num_slices"]}')
+    print(f'{raw_keys["compile_topology_num_slices"]}')
     if raw_keys["enable_checkpointing"] and raw_keys["async_checkpointing"] and raw_keys["compile_topology_num_slices"] is None:
       max_utils.initialize_jax_distributed_system()
 

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -97,8 +97,7 @@ class _HyperParameters():
     '''Transformations between the config data and configs used at runtime'''
 
     # We initialize the jax distributed system here because it must be done before device backend is initialized.
-    print(f'{raw_keys["compile_topology_num_slices"]}')
-    if raw_keys["enable_checkpointing"] and raw_keys["async_checkpointing"] and raw_keys["compile_topology_num_slices"] is None:
+    if raw_keys["enable_checkpointing"] and raw_keys["async_checkpointing"] and raw_keys["compile_topology_num_slices"]==-1:
       max_utils.initialize_jax_distributed_system()
 
     raw_keys["dtype"] = jax.numpy.dtype(raw_keys["dtype"])

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -98,7 +98,7 @@ class _HyperParameters():
 
     # We initialize the jax distributed system here because it must be done before device backend is initialized.
     print(f'{raw_keys["compile_num_slices"]}')
-    if raw_keys["enable_checkpointing"] and raw_keys["async_checkpointing"] and raw_keys["compile_num_slices"] is None:
+    if raw_keys["enable_checkpointing"] and raw_keys["async_checkpointing"] and raw_keys["compile_topology_num_slices"] is None:
       max_utils.initialize_jax_distributed_system()
 
     raw_keys["dtype"] = jax.numpy.dtype(raw_keys["dtype"])

--- a/MaxText/tests/attention_test.py
+++ b/MaxText/tests/attention_test.py
@@ -31,7 +31,7 @@ class AttentionTest(unittest.TestCase):
   """Test for the Attention """
   def setUp(self):
     super().setUp()
-    pyconfig.initialize(sys.argv + ['configs/base.yml'], per_device_batch_size = 1.0, run_name='test')
+    pyconfig.initialize(sys.argv + ['configs/base.yml'], per_device_batch_size = 1.0, run_name='test', enable_checkpointing=False)
     self.cfg = pyconfig.config
     self.rng = jax.random.PRNGKey(0)
 

--- a/MaxText/tests/attention_test.py
+++ b/MaxText/tests/attention_test.py
@@ -31,7 +31,7 @@ class AttentionTest(unittest.TestCase):
   """Test for the Attention """
   def setUp(self):
     super().setUp()
-    pyconfig.initialize(sys.argv + ['configs/base.yml'], per_device_batch_size = 1.0, run_name='test', enable_checkpointing=False)
+    pyconfig.initialize(sys.argv + ['configs/base.yml'], per_device_batch_size = 1.0, run_name='test')
     self.cfg = pyconfig.config
     self.rng = jax.random.PRNGKey(0)
 

--- a/MaxText/tests/input_pipeline_test.py
+++ b/MaxText/tests/input_pipeline_test.py
@@ -38,7 +38,8 @@ class InputPipelineTest(unittest.TestCase):
     super().setUp()
     pyconfig.initialize(sys.argv + ['configs/base.yml'], per_device_batch_size=1, run_name='test', mesh_axes = ['data'],
                         logical_axis_rules = [['batch', 'data']],
-                        data_sharding = ['data'])
+                        data_sharding = ['data'],
+                        enable_checkpointing=False)
     os.environ["TFDS_DATA_DIR"] = pyconfig.config.dataset_path
     self.config = pyconfig.config
     self.read_config = tfds.ReadConfig()

--- a/MaxText/tests/input_pipeline_test.py
+++ b/MaxText/tests/input_pipeline_test.py
@@ -38,8 +38,7 @@ class InputPipelineTest(unittest.TestCase):
     super().setUp()
     pyconfig.initialize(sys.argv + ['configs/base.yml'], per_device_batch_size=1, run_name='test', mesh_axes = ['data'],
                         logical_axis_rules = [['batch', 'data']],
-                        data_sharding = ['data'],
-                        enable_checkpointing=False)
+                        data_sharding = ['data'])
     os.environ["TFDS_DATA_DIR"] = pyconfig.config.dataset_path
     self.config = pyconfig.config
     self.read_config = tfds.ReadConfig()

--- a/MaxText/tests/multihost_dataloading_test.py
+++ b/MaxText/tests/multihost_dataloading_test.py
@@ -38,8 +38,7 @@ class MultihostDataloadingTest(unittest.TestCase):
                         logical_axis_rules = [['batch', 'data']],
                         data_sharding = ['data'],
                         base_output_directory = "gs://max-experiments/",
-                        dataset_path = "gs://maxtext-dataset/",
-                        enable_checkpointing=False)
+                        dataset_path = "gs://maxtext-dataset/")
     config = pyconfig.config
     global_data_shape = PartitionSpec(batch_size, config.max_target_length)
     data_sharding = ('data',)

--- a/MaxText/tests/multihost_dataloading_test.py
+++ b/MaxText/tests/multihost_dataloading_test.py
@@ -38,7 +38,8 @@ class MultihostDataloadingTest(unittest.TestCase):
                         logical_axis_rules = [['batch', 'data']],
                         data_sharding = ['data'],
                         base_output_directory = "gs://max-experiments/",
-                        dataset_path = "gs://maxtext-dataset/")
+                        dataset_path = "gs://maxtext-dataset/",
+                        enable_checkpointing=False)
     config = pyconfig.config
     global_data_shape = PartitionSpec(batch_size, config.max_target_length)
     data_sharding = ('data',)

--- a/MaxText/tests/train_compile_test.py
+++ b/MaxText/tests/train_compile_test.py
@@ -23,15 +23,11 @@ from train import main as train_main
 class TrainCompile(unittest.TestCase):
   """Tests for the Ahead of Time Compilation functionality, train_compile.py"""
 
-  def test_save_and_restore_v4_8(self):
+  def test_save_compiled(self):
     compiled_trainstep_file='test_compiled.pickle'
     train_compile_main((None, "configs/base.yml", f"compiled_trainstep_file={compiled_trainstep_file}",
       "compile_topology=v4-8", "compile_topology_num_slices=1", "base_emb_dim=256", "base_mlp_dim=256",
       "base_num_decoder_layers=2"))
-    train_main((None, "configs/base.yml", f"compiled_trainstep_file={compiled_trainstep_file}",
-      r"base_output_directory=gs://runner-maxtext-logs", r"dataset_path=gs://maxtext-dataset",
-      "steps=2", "run_name=runner_compile_load_test", "enable_checkpointing=False", "assets_path=../assets",
-      "base_emb_dim=256", "base_mlp_dim=256", "base_num_decoder_layers=2"))
   
   def test_sequence_parallelism(self):
     compiled_trainstep_file='test_compiled.pickle'

--- a/MaxText/tests/train_smoke_test.py
+++ b/MaxText/tests/train_smoke_test.py
@@ -30,7 +30,7 @@ class Train(unittest.TestCase):
       r"dataset_path=gs://maxtext-dataset",
       "base_emb_dim=8", "base_num_heads=4", "base_mlp_dim=32",
       "base_num_decoder_layers=8", "head_dim=16", "per_device_batch_size=2",
-      "max_target_length=1024", "dataset_type=synthetic", "steps=10"])
+      "max_target_length=1024", "dataset_type=synthetic", "steps=10", "enable_checkpointing=False"])
 
 if __name__ == '__main__':
   absltest.main()

--- a/MaxText/tests/train_smoke_test.py
+++ b/MaxText/tests/train_smoke_test.py
@@ -30,7 +30,7 @@ class Train(unittest.TestCase):
       r"dataset_path=gs://maxtext-dataset",
       "base_emb_dim=8", "base_num_heads=4", "base_mlp_dim=32",
       "base_num_decoder_layers=8", "head_dim=16", "per_device_batch_size=2",
-      "max_target_length=1024", "dataset_type=synthetic", "steps=10", "enable_checkpointing=False"])
+      "max_target_length=1024", "dataset_type=synthetic", "steps=10"])
 
 if __name__ == '__main__':
   absltest.main()

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -318,7 +318,8 @@ def main(argv: Sequence[str]) -> None:
   jax.config.update('jax_default_prng_impl', 'unsafe_rbg')
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
   os.environ["LIBTPU_INIT_ARGS"] = os.environ.get("LIBTPU_INIT_ARGS","") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
-  print(f"Found {jax.device_count()} devices.")
+  max_utils.initialize_jax_distributed_system()
+  print(f"Found {jax.device_count()} devices.") # This is the first command that initializes the device backend.
   cc.initialize_cache(os.path.expanduser("~/jax_cache"))
   pyconfig.initialize(argv)
   config = pyconfig.config

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -318,10 +318,9 @@ def main(argv: Sequence[str]) -> None:
   jax.config.update('jax_default_prng_impl', 'unsafe_rbg')
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
   os.environ["LIBTPU_INIT_ARGS"] = os.environ.get("LIBTPU_INIT_ARGS","") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
-  max_utils.initialize_jax_distributed_system()
-  print(f"Found {jax.device_count()} devices.")
   cc.initialize_cache(os.path.expanduser("~/jax_cache"))
   pyconfig.initialize(argv)
+  print(f"Found {jax.device_count()} devices.")
   config = pyconfig.config
   validate_train_config(config)
   os.environ["TFDS_DATA_DIR"] = config.dataset_path

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -318,8 +318,7 @@ def main(argv: Sequence[str]) -> None:
   jax.config.update('jax_default_prng_impl', 'unsafe_rbg')
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
   os.environ["LIBTPU_INIT_ARGS"] = os.environ.get("LIBTPU_INIT_ARGS","") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
-  max_utils.initialize_jax_distributed_system()
-  print(f"Found {jax.device_count()} devices.") # This is the first command that initializes the device backend.
+  print(f"Found {jax.device_count()} devices.")
   cc.initialize_cache(os.path.expanduser("~/jax_cache"))
   pyconfig.initialize(argv)
   config = pyconfig.config

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -318,6 +318,7 @@ def main(argv: Sequence[str]) -> None:
   jax.config.update('jax_default_prng_impl', 'unsafe_rbg')
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
   os.environ["LIBTPU_INIT_ARGS"] = os.environ.get("LIBTPU_INIT_ARGS","") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
+  max_utils.initialize_jax_distributed_system()
   print(f"Found {jax.device_count()} devices.")
   cc.initialize_cache(os.path.expanduser("~/jax_cache"))
   pyconfig.initialize(argv)


### PR DESCRIPTION
Initialize the jax distributed system before the device backend.

Tested:

Jax 0.4.20 (basically a refactor here, just calling the initialize earlier in code):
* Single slice QR

Jax nightly 0.4.21.dev-xxx (hits the new jax.distributed.initialize() without args):
* Single slice QR
* Multi slice QR
* Single slice GKE
* Multi slice GKE