### PR TITLE
Increase --shm-size for docker run on GPU

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -91,24 +91,24 @@ jobs:
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c "pylint MaxText/"
     - name: Test with pytest
       run: |
-        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c 'cd MaxText;python3 -m pytest -m "not tpu"'
+        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --shm-size=1g --rm --privileged maxtext_base_image bash -c 'cd MaxText;python3 -m pytest -m "not tpu"'
     - name: Test train.py
       run: |
-        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
+        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --shm-size=1g --rm --privileged maxtext_base_image bash -c \
         'python3 MaxText/train.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M) base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset steps=2 enable_checkpointing=false attention=mha'
     - name: Test train.py with per_device_batch_size < 1
       run: |
-        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
+        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --shm-size=1g --rm --privileged maxtext_base_image bash -c \
         'python3 MaxText/train.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M) base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset steps=2 per_device_batch_size=0.25 ici_tensor_parallelism=4 enable_checkpointing=false attention=mha'
     - name: Test decode.py
       run: |
-        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
+        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --shm-size=1g --rm --privileged maxtext_base_image bash -c \
         'python3 MaxText/decode.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M) base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset steps=2 ici_tensor_parallelism=4 attention="mha" enable_checkpointing=false'
     - name: Test int8_training
       run: |
-        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
+        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --shm-size=1g --rm --privileged maxtext_base_image bash -c \
         'python3 MaxText/train.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M) base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset int8_training=true steps=2 enable_checkpointing=false attention=mha'
     - name: Test test_decode_checkpoint
       run: |
-        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
+        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --shm-size=1g --rm --privileged maxtext_base_image bash -c \
         'bash end_to_end/test_decode_checkpoint.sh -r runner_$(date +%Y-%m-%d-%H-%M) -o gs://runner-maxtext-logs -d gs://maxtext-dataset -i 4 -a mha'

--- a/docker_build_dependency_image.sh
+++ b/docker_build_dependency_image.sh
@@ -69,7 +69,7 @@ echo ""
 echo "Built your base docker image and named it ${LOCAL_IMAGE_NAME}.
 It only has the dependencies installed. Assuming you're on a TPUVM, to run the
 docker image locally and mirror your local working directory run:"
-echo "docker run -v $(pwd):/app --rm -it --privileged --entrypoint bash ${LOCAL_IMAGE_NAME}"
+echo "docker run -v $(pwd):/app --shm-size=1g --rm -it --privileged --entrypoint bash ${LOCAL_IMAGE_NAME}"
 echo ""
 echo "You can run MaxText and your development tests inside of the docker image. Changes to your workspace will automatically
 be reflected inside the docker container."


### PR DESCRIPTION
* `--shm-size`  is increased to `1g` for `docker run` on GPU because the default value of 64mb might not be sufficient for other set of GPUs (e.g. A100-40gb-8)
* `--shm-size=1g` is added to the docker run command shown at the end of `docker_build_dependency_image.sh`, to give good guidance to users
* README is updated accordingly