### PR TITLE
Add profiling to nightly TFLOPS test

### DIFF
--- a/end_to_end/test_tflops.sh
+++ b/end_to_end/test_tflops.sh
@@ -16,7 +16,7 @@ fi
 
 #Train
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
-    steps=150 reuse_example_batch=1 remat_policy='full' enable_checkpointing=False metrics_file='metrics.txt'\
+    steps=150 reuse_example_batch=1 remat_policy='full' enable_profiler=True enable_checkpointing=False metrics_file='metrics.txt'\
     base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH log_period=150
 
 python3 end_to_end/eval_assert.py metrics_average metrics.txt $TFLOP_THRESHOLD perf/per_device_tflops_per_sec


### PR DESCRIPTION
Add traces to the nightly tflops test.

This will allow us to integrate with tools to track the performance overtime.