### PR TITLE
Set up pytype on CI tests

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -43,6 +43,9 @@ jobs:
     - name: Install dependencies
       run: |
         bash docker_build_dependency_image.sh
+    - name: Typecheck the code with pytype
+      run: |
+        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c "pytype --jobs auto --disable import-error MaxText/"
     - name: Analysing the code with pylint
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c "pylint MaxText/"
@@ -86,6 +89,9 @@ jobs:
     - name: Install dependencies
       run: |
         bash docker_build_dependency_image.sh DEVICE=gpu
+    - name: Typecheck the code with pytype
+      run: |
+        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c "pytype --jobs auto --disable import-error MaxText/"
     - name: Analysing the code with pylint
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c "pylint MaxText/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ portpicker
 protobuf==3.20.3
 pylint
 pytest
+pytype
 sentencepiece==0.1.97
 tensorflow-datasets
 tensorflow-text


### PR DESCRIPTION
 - `import-error` is disabled because the external pytype is reporting 'false' errors
 - pytype check is run only on files under `MaxText/`