### PR TITLE
Standalone dataloader for Maxtext storage emulator

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -68,6 +68,10 @@ jobs:
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
         'python3 MaxText/decode.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M) base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset steps=2 ici_tensor_parallelism=4 attention=dot_product enable_checkpointing=false max_target_length=128 per_device_batch_size=.25'
+    - name: Test standalone_dataloader.py
+      run: |
+        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
+        'python3 MaxText/standalone_dataloader.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M) base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset steps=100 enable_checkpointing=false'  
     - name: Test int8_training
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \

--- a/MaxText/standalone_dataloader.py
+++ b/MaxText/standalone_dataloader.py
@@ -1,0 +1,74 @@
+"""
+ Copyright 2023 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      https://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+# pylint: disable=g-bad-todo, abstract-method, consider-using-with, ungrouped-imports
+""" Standalone data loader - only loads data for each training step, accesses storage needs."""
+
+# Calling jax.device_count here prevents a "TPU platform already registered" error.
+# See github.com/google/maxtext/issues/20 for more
+import jax
+import os
+
+from typing import Sequence
+import datetime
+from absl import app
+import numpy as np
+
+import pyconfig
+from train import validate_train_config, get_first_step, load_next_batch, setup_train_loop
+
+from jax.experimental.compilation_cache import compilation_cache as cc
+
+
+def data_load_loop(config, state=None):
+  """Main data loader loop.
+    Loads batches of data for each training step.
+  """
+  _, _, _, _, _, _, _, data_iterator, state = setup_train_loop(config)
+
+  example_batch = None
+
+  start = datetime.datetime.now()
+  start_step = get_first_step(state)
+  example_batch = load_next_batch(data_iterator, example_batch, config)
+  first_end = datetime.datetime.now()
+  time_to_load_first_batch = first_end-start
+  print("First step completed in ",time_to_load_first_batch ," seconds")
+
+  for _ in np.arange(start_step+1, config.steps):
+    example_batch = load_next_batch(data_iterator, example_batch, config)
+
+  jax.block_until_ready(example_batch) # wait until the last batch is read
+  end = datetime.datetime.now()
+  print(config.steps," batches loaded in ", end-start ," seconds, on host ", jax.process_index())
+  return state
+
+
+def main(argv: Sequence[str]) -> None:
+  jax.config.update('jax_default_prng_impl', 'unsafe_rbg')
+  os.environ["LIBTPU_INIT_ARGS"] = os.environ.get("LIBTPU_INIT_ARGS","") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
+  os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
+  pyconfig.initialize(argv)
+  config = pyconfig.config
+  validate_train_config(config)
+  cc.initialize_cache(os.path.expanduser(config.jax_cache_dir))
+  print(f"Found {jax.device_count()} devices.")
+  print(f"Found {jax.process_count()} processes.")
+  print(f"Found {jax.devices()} devices.")
+  os.environ["TFDS_DATA_DIR"] = config.dataset_path
+  data_load_loop(config)
+
+
+
+if __name__ == "__main__":
+  app.run(main)

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -211,16 +211,24 @@ def train_step(model, config, state, data, dropout_rng):
 
   return new_state, metrics, rng2
 
-def train_loop(config, state=None):
-  """Main Training loop.
+def setup_train_loop(config):
+  """ Set up prerequisites for the training loop -
+      checkpoint_manager, PRNG keys, Mesh, Model and optimizer.
+      Set up data iterator and tokenizer, initialize the model.
 
   Args:
-    config:
-    state:
-    ckpt_path:
+    config
 
   Returns:
-
+    writer: Summary writer for tensorboard
+    checkpoint_manager: Orbax checkpointer
+    nextrng: key used in train_step for dropout
+    state_mesh_annotations: the mesh annotations for the train state 
+    model:
+    mesh: 
+    learning_rate_schedule:
+    data_iterator: 
+    state: the initialized train state
   """
   writer = SummaryWriter(config.tensorboard_dir)
   checkpoint_manager = checkpointing.create_orbax_checkpoint_manager(
@@ -244,6 +252,22 @@ def train_loop(config, state=None):
   data_iterator, _ = create_data_iterator_with_tokenizer(config, mesh)
 
   state, state_mesh_annotations = max_utils.setup_training_state(model, tx, config, init_rng, mesh, checkpoint_manager)
+
+  return ( writer, checkpoint_manager, nextrng, state_mesh_annotations, model,
+          mesh, learning_rate_schedule, data_iterator, state)
+
+
+def train_loop(config, state=None):
+  """Main Training loop.
+  Args:
+    config:
+    state:
+    ckpt_path:
+  Returns:
+  """
+  ( writer, checkpoint_manager, nextrng, state_mesh_annotations, model,
+  mesh, learning_rate_schedule, data_iterator, state) = setup_train_loop(config)
+
   functional_train, in_shard, out_shard, static_argnums, donate_argnums = maxtext_utils.get_functional_train_with_signature(
     train_step,
     mesh,


### PR DESCRIPTION
The standalone data loader, sets up the model and data iterator similar to the train_loop of train.py. The data loader iterates through batches of data, to log step time of the first step and time taken to load all the batches, but does not actually train the model.

The data loader mimics the interactions of the TPU VM hosts with the storage systems such as GCS.

Added a github workflow unit test for running standalone_dataloader.py separately.

Cleaner version of https://github.com/google/maxtext/pull/283