### PR TITLE
RoPE Swap

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -83,7 +83,7 @@ jobs:
     - name: Test llama2_decode.py
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
-        'python3 MaxText/decode.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M) base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset load_from_other_directory=gs://maxtext-llama/llama2-7b/decode-ckpt-maxtext load_from_other_directory_step=0 per_device_batch_size=1 model_name='llama2-7b' assets_path=gs://maxtext-llama/llama2-7b ici_tensor_parallelism=4 steps=1 max_prefill_predict_length=4  max_target_length=16 async_checkpointing=false prompt="I love to" autoregressive_decode_assert="read. I love to write. I love to share."'
+        'bash end_to_end/llama_load_and_test.sh'
   
   # IF YOU MODIFY THIS, YOU SHOULD ALSO ADD CORRESPONDING MODICATIONS TO 'tpu' job
   gpu:

--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -41,7 +41,7 @@ Mesh = common_types.Mesh
 PRNGKey = common_types.PRNGKey
 
 DenseGeneral = linears.DenseGeneral
-LLaMARotaryEmbedding = embeddings.LLaMARotaryEmbedding
+RotaryEmbedding = embeddings.RotaryEmbedding
 NdInitializer = initializers.NdInitializer
 
 AxisNames = common_types.AxisNames
@@ -621,7 +621,7 @@ class Attention(nn.Module):
 
   def key_rotary(self, key: Array, inputs_positions: Array):
     """Apply Rotary Embedding to key."""
-    key = LLaMARotaryEmbedding(
+    key = RotaryEmbedding(
       embedding_dims=self.head_dim,
       name='key_rotary')(inputs=key, position=inputs_positions)
     return key
@@ -663,7 +663,7 @@ class Attention(nn.Module):
     value = self.kv_projection(inputs_kv, proj_name='value')
 
     # apply ROPE
-    query = LLaMARotaryEmbedding(
+    query = RotaryEmbedding(
         embedding_dims=self.head_dim, name='query_rotary'
     )(inputs=query, position=inputs_positions)
     key = self.key_rotary(key, inputs_positions)

--- a/MaxText/layers/embeddings.py
+++ b/MaxText/layers/embeddings.py
@@ -102,8 +102,8 @@ class Embed(nn.Module):
     return jnp.dot(query, jnp.asarray(self.embedding, dtype).T)
 
 
-class LLaMARotaryEmbedding(nn.Module):
-  """LLaMA variant of ROPE where inputs are split in a different way.
+class RotaryEmbedding(nn.Module):
+  """RoPE
 
   Attributes:
     min_timescale: Start of the geometric index. Determines the periodicity of
@@ -167,8 +167,9 @@ class LLaMARotaryEmbedding(nn.Module):
     sin = jnp.sin(sinusoid_inp)
     cos = jnp.cos(sinusoid_inp)
     reshape_tensor = inputs.astype(jnp.float32).reshape(
-        *inputs.shape[:-1], -1, 2
+        *inputs.shape[:-1], 2, -1
     )
+    reshape_tensor = jax.numpy.swapaxes(reshape_tensor, -1, -2)
     first_half = reshape_tensor[..., 0]
     second_half = reshape_tensor[..., 1]
     first_part = first_half * cos - second_half * sin

--- a/MaxText/layers/llama2.py
+++ b/MaxText/layers/llama2.py
@@ -43,9 +43,7 @@ Mesh = common_types.Mesh
 ScanIn = common_types.ScanIn
 
 Embed = embeddings.Embed
-LLaMARotaryEmbedding = embeddings.LLaMARotaryEmbedding
 Attention = attentions.Attention
-AttentionOp = attentions.AttentionOp
 RMSNorm = normalizations.RMSNorm
 
 

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -35,7 +35,6 @@ Mesh = common_types.Mesh
 ScanIn = common_types.ScanIn
 
 Embed = embeddings.Embed
-LLaMARotaryEmbedding = embeddings.LLaMARotaryEmbedding
 Attention = attentions.Attention
 RMSNorm = normalizations.RMSNorm
 

--- a/MaxText/tests/attention_test.py
+++ b/MaxText/tests/attention_test.py
@@ -33,7 +33,6 @@ from layers import embeddings
 
 Mesh = jax.sharding.Mesh
 Attention = attentions.Attention
-LLaMARotaryEmbedding = embeddings.LLaMARotaryEmbedding
 
 
 class AttentionTest(unittest.TestCase):

--- a/end_to_end/llama_load_and_test.sh
+++ b/end_to_end/llama_load_and_test.sh
@@ -1,0 +1,6 @@
+set -e
+idx=$(date +%Y-%m-%d-%H-%M)
+pip install torch
+gsutil cp -r gs://maxtext-llama/llama2-7b/meta-ckpt /tmp/
+python3 MaxText/convert_llama_ckpt.py --base-model-path /tmp/meta-ckpt --model-size 7b --maxtext-model-path gs://maxtext-llama/test/${idx}/decode-ckpt-maxtext/
+python3 MaxText/decode.py MaxText/configs/base.yml run_name=runner_${idx} base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset load_from_other_directory=gs://maxtext-llama/test/${idx}/decode-ckpt-maxtext/ load_from_other_directory_step=0 per_device_batch_size=1 model_name='llama2-7b' assets_path=gs://maxtext-llama/llama2-7b ici_tensor_parallelism=4 steps=1 max_prefill_predict_length=4  max_target_length=16 async_checkpointing=false prompt="I love to" autoregressive_decode_assert="read. I love to write. I love to share." attention=dot_product


### PR DESCRIPTION
Old ROPE: https://xprof.corp.google.com/trace_viewer/rwitten-4594820510599561546
New ROPE https://xprof.corp.google.com/trace_viewer/rwitten-18415982956965554229
1.237 s -> 1.205 s, 2.5% on this 1B on a v4-8, less on bigger models probably.

Special thanks Adam Paszke for putting us onto this optimization