### PR TITLE
Add kubectl and gke-gcloud-auth-plugin to maxtext dependency dockerfile

### DIFF
--- a/maxtext_dependencies.Dockerfile
+++ b/maxtext_dependencies.Dockerfile
@@ -14,6 +14,10 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyri
 # Install the Google Cloud SDK
 RUN apt-get update && apt-get install -y google-cloud-sdk
 
+# Install kubectl and gke-gcloud-auth-plugin components needed for KubernetesPodOperator
+RUN apt-get install -y kubectl
+RUN apt-get install -y google-cloud-sdk-gke-gcloud-auth-plugin
+
 # Set the default Python version to 3.10
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.10 1
 


### PR DESCRIPTION
This change is needed to be able to run MaxText/XPK-based XLML tests on the new Airflow-based infra. The infra executes the XPK command using KubernetesPodOperator on the docker image https://github.com/GoogleCloudPlatform/ml-auto-solutions/blob/a0287d3730ccd9d2b24ac2339dbb1cd42386f9e7/xlml/utils/xpk.py#L50-L57. KubernetesPodOperator needs `kubectl` and `google-cloud-sdk-gke-gcloud-auth-plugin`.