### PR TITLE
Enable profiler at all workers and upload all xplane results to GCS

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -169,6 +169,8 @@ add_eos: True
 autoregressive_decode_assert: ""
 
 enable_profiler: False
+# If set to true, upload all profiler xplane results from all hosts. Otherwise, only upload the xplane reuslt from the first host.
+upload_all_profiler_results: False
 # Skip first n steps for profiling, to omit things like compilation and to give
 # the iteration time a chance to stabilize.
 skip_first_n_steps_for_profiler: 1

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -69,11 +69,11 @@ def summarize_size_from_pytree(params):
   return num_params, num_bytes, num_bytes/num_params
 
 def activate_profiler(config):
-  if jax.process_index() == 0 and config.enable_profiler:
+  if config.enable_profiler and (config.upload_all_profiler_results or jax.process_index() == 0):
     jax.profiler.start_trace(config.tensorboard_dir)
 
 def deactivate_profiler(config):
-  if jax.process_index() == 0 and config.enable_profiler:
+  if config.enable_profiler and (config.upload_all_profiler_results or jax.process_index() == 0):
     jax.profiler.stop_trace()
 
 def _prepare_metrics_for_json(metrics, step, run_name):


### PR DESCRIPTION
Currently, maxtext only upload the xplane result to GCS from `jax.process_index(0)`, this only includes one xplane result from the first host. 

I added a flag `upload_all_profiler_results` and this flag is set to False by default. If set to True, maxtext will upload all xplane results to GCS from all hosts. Otherwise, it will only upload one xplane result from the first host. 

Providing all xplane will help MXLA team to gather all trace info and debug.

I did the tests on 8 slices of v4-8