### PR TITLE
refactor input_pipeline.py and fix test

### DIFF
--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -29,7 +29,7 @@ import numpy as np
 
 import pyconfig
 import max_utils
-from input_pipeline import create_data_iterator_with_tokenizer
+from input_pipeline.input_pipeline_interface import create_data_iterator_with_tokenizer
 from layers import models
 
 import common_types

--- a/MaxText/input_pipeline/_tfds_data_processing.py
+++ b/MaxText/input_pipeline/_tfds_data_processing.py
@@ -23,8 +23,6 @@ import ml_collections
 import tensorflow as tf
 import tensorflow_datasets as tfds
 import jax
-import jax.numpy as jnp
-from jax.sharding import PartitionSpec as P
 
 import tokenizer
 import multihost_dataloading
@@ -269,77 +267,3 @@ def preprocess_dataset(config: ml_collections.ConfigDict,
 
   return train_iter, eval_iter, predict_iter, sp_tokenizer
 
-
-def make_c4_train_iterator_and_tokenizer(config, mesh, add_bos, add_eos):
-  """ Make train iterator and tokenizer for C4 dataset"""
-  read_config = tfds.ReadConfig(
-    shuffle_seed = config.data_shuffle_seed,
-  )
-  train_ds, eval_ds = get_datasets(
-    config=config,
-    read_config = read_config,
-  )
-  train_iter, _, _, sp_tokenizer = preprocess_dataset(
-    config,
-    mesh,
-    train_ds, eval_ds,
-    vocab_path=os.path.join(config.assets_path, config.vocab_relative_path),
-    data_shuffle_seed = config.data_shuffle_seed,
-    add_bos = add_bos,
-    add_eos = add_eos
-  )
-  return train_iter, sp_tokenizer
-
-class SyntheticDataIterator():
-  """Creates a synthetic data iterator for performance testing work"""
-  def __init__(self, config, mesh):
-    self.mesh = mesh
-    self.config = config
-    data_pspec = P(*config.data_sharding)
-    data_pspec_shardings = jax.tree_map(
-        lambda p: jax.sharding.NamedSharding(mesh, p), data_pspec)
-    self.data_generator = jax.jit(SyntheticDataIterator.raw_generate_synthetic_data,
-        out_shardings=data_pspec_shardings,
-        static_argnums=0)
-  def __call__(self):
-    with self.mesh:
-      return self.data_generator(self.config)
-
-  @staticmethod
-  def raw_generate_synthetic_data(config):
-    """Generates a single batch of syntehtic data"""
-    output = {}
-    output['inputs'] = jax.numpy.zeros( (config.global_batch_size_to_load, config.max_target_length),
-                                       dtype=jax.numpy.int32)
-    output['inputs_position'] = jax.numpy.zeros( (config.global_batch_size_to_load, config.max_target_length),
-                                                dtype=jax.numpy.int32)
-    output['inputs_segmentation'] = jax.numpy.ones( (config.global_batch_size_to_load, config.max_target_length),
-                                                   dtype=jax.numpy.int32)
-    output['targets'] = jax.numpy.zeros( (config.global_batch_size_to_load, config.max_target_length),
-                                        dtype=jax.numpy.int32)
-    output['targets_position'] = jax.numpy.zeros( (config.global_batch_size_to_load, config.max_target_length),
-                                                 dtype=jax.numpy.int32)
-    output['targets_segmentation'] = jax.numpy.ones( (config.global_batch_size_to_load, config.max_target_length),
-                                                    dtype=jax.numpy.int32)
-    return output
-
-def create_data_iterator_with_tokenizer(config, mesh, add_bos = True, add_eos = True):
-  if config.dataset_type == "synthetic":
-    return SyntheticDataIterator(config, mesh), None
-  elif config.dataset_type == "c4":
-    return make_c4_train_iterator_and_tokenizer(config, mesh, add_bos, add_eos)
-  else:
-    assert False, "dataset type not implemented"
-
-def get_shaped_batch(config):
-  """ Return the shape of the batch - this is what eval_shape would return for the
-  output of create_data_iterator_with_tokenizer, but eval_shape doesn't work, see b/306901078."""
-  batch_shape = (config.global_batch_size_to_load, config.max_target_length)
-  shaped_batch = {}
-  shaped_batch['inputs'] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
-  shaped_batch['inputs_position'] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
-  shaped_batch['inputs_segmentation'] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
-  shaped_batch['targets'] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
-  shaped_batch['targets_position'] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
-  shaped_batch['targets_segmentation'] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
-  return shaped_batch

--- a/MaxText/input_pipeline/input_pipeline_interface.py
+++ b/MaxText/input_pipeline/input_pipeline_interface.py
@@ -1,0 +1,101 @@
+"""
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+"""Input pipeline"""
+
+import os
+
+import tensorflow_datasets as tfds
+import jax
+import jax.numpy as jnp
+from jax.sharding import PartitionSpec as P
+
+from input_pipeline import _tfds_data_processing
+
+
+def make_c4_train_iterator_and_tokenizer(config, mesh, add_bos, add_eos):
+  """ Make train iterator and tokenizer for C4 dataset"""
+  read_config = tfds.ReadConfig(
+    shuffle_seed = config.data_shuffle_seed,
+  )
+  train_ds, eval_ds = _tfds_data_processing.get_datasets(
+    config=config,
+    read_config = read_config,
+  )
+  train_iter, _, _, sp_tokenizer = _tfds_data_processing.preprocess_dataset(
+    config,
+    mesh,
+    train_ds, eval_ds,
+    vocab_path=os.path.join(config.assets_path, config.vocab_relative_path),
+    data_shuffle_seed = config.data_shuffle_seed,
+    add_bos = add_bos,
+    add_eos = add_eos
+  )
+  return train_iter, sp_tokenizer
+
+class SyntheticDataIterator():
+  """Creates a synthetic data iterator for performance testing work"""
+  def __init__(self, config, mesh):
+    self.mesh = mesh
+    self.config = config
+    data_pspec = P(*config.data_sharding)
+    data_pspec_shardings = jax.tree_map(
+        lambda p: jax.sharding.NamedSharding(mesh, p), data_pspec)
+    self.data_generator = jax.jit(SyntheticDataIterator.raw_generate_synthetic_data,
+        out_shardings=data_pspec_shardings,
+        static_argnums=0)
+  def __call__(self):
+    with self.mesh:
+      return self.data_generator(self.config)
+
+  @staticmethod
+  def raw_generate_synthetic_data(config):
+    """Generates a single batch of syntehtic data"""
+    output = {}
+    output['inputs'] = jax.numpy.zeros( (config.global_batch_size_to_load, config.max_target_length),
+                                       dtype=jax.numpy.int32)
+    output['inputs_position'] = jax.numpy.zeros( (config.global_batch_size_to_load, config.max_target_length),
+                                                dtype=jax.numpy.int32)
+    output['inputs_segmentation'] = jax.numpy.ones( (config.global_batch_size_to_load, config.max_target_length),
+                                                   dtype=jax.numpy.int32)
+    output['targets'] = jax.numpy.zeros( (config.global_batch_size_to_load, config.max_target_length),
+                                        dtype=jax.numpy.int32)
+    output['targets_position'] = jax.numpy.zeros( (config.global_batch_size_to_load, config.max_target_length),
+                                                 dtype=jax.numpy.int32)
+    output['targets_segmentation'] = jax.numpy.ones( (config.global_batch_size_to_load, config.max_target_length),
+                                                    dtype=jax.numpy.int32)
+    return output
+
+def create_data_iterator_with_tokenizer(config, mesh, add_bos = True, add_eos = True):
+  if config.dataset_type == "synthetic":
+    return SyntheticDataIterator(config, mesh), None
+  elif config.dataset_type == "c4":
+    return make_c4_train_iterator_and_tokenizer(config, mesh, add_bos, add_eos)
+  else:
+    assert False, "dataset type not implemented"
+
+def get_shaped_batch(config):
+  """ Return the shape of the batch - this is what eval_shape would return for the
+  output of create_data_iterator_with_tokenizer, but eval_shape doesn't work, see b/306901078."""
+  batch_shape = (config.global_batch_size_to_load, config.max_target_length)
+  shaped_batch = {}
+  shaped_batch['inputs'] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
+  shaped_batch['inputs_position'] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
+  shaped_batch['inputs_segmentation'] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
+  shaped_batch['targets'] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
+  shaped_batch['targets_position'] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
+  shaped_batch['targets_segmentation'] = jax.ShapeDtypeStruct(batch_shape, jnp.int32)
+  return shaped_batch

--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -24,7 +24,7 @@ from jax.experimental.serialize_executable import deserialize_and_load
 
 import pickle
 import functools
-import input_pipeline
+from input_pipeline import input_pipeline_interface
 import optax
 
 
@@ -75,7 +75,7 @@ def load_compiled(config, partial_train, state):
     return in_tree_recreated, out_tree_recreated
 
   serialized_compiled = load_serialized_compiled(config.compiled_trainstep_file)
-  shaped_batch = input_pipeline.get_shaped_batch(config)
+  shaped_batch = input_pipeline_interface.get_shaped_batch(config)
   example_rng = jax.random.PRNGKey(0)
   shaped_input_args = (state, shaped_batch, example_rng)
   shaped_input_kwargs = {}

--- a/MaxText/pytest.ini
+++ b/MaxText/pytest.ini
@@ -3,6 +3,6 @@
 testpaths =
     tests
 python_files = *_test.py
-addopts = -rf --import-mode=importlib --ignore=tests/input_pipeline_test.py --ignore=tests/profiler_test.py --ignore=tests/train_smoke_test.py
+addopts = -rf --import-mode=importlib --ignore=tests/profiler_test.py --ignore=tests/train_smoke_test.py
 markers = 
     tpu: marks tests to be run on TPU

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -39,7 +39,7 @@ import maxtext_utils
 import max_logging
 import pyconfig
 
-from input_pipeline import create_data_iterator_with_tokenizer
+from input_pipeline.input_pipeline_interface import create_data_iterator_with_tokenizer
 from layers import models
 
 import jax.numpy as jnp

--- a/MaxText/train_compile.py
+++ b/MaxText/train_compile.py
@@ -37,7 +37,7 @@ from absl import app
 import pickle
 import accelerator_to_spec_map
 import train
-import input_pipeline
+from input_pipeline import input_pipeline_interface
 
 Transformer = models.Transformer
 
@@ -79,7 +79,7 @@ def get_shaped_inputs(topology_mesh, config):
   abstract_state, state_mesh_annotations =  max_utils.get_abstract_state(model, tx, config, example_rng, topology_mesh)
 
   # Shaped batch
-  shaped_batch = input_pipeline.get_shaped_batch(config)
+  shaped_batch = input_pipeline_interface.get_shaped_batch(config)
 
   shaped_train_args = (abstract_state, shaped_batch, shaped_rng)
   shaped_train_kwargs = {}


### PR DESCRIPTION
1. the original input_pipeline.py was refactored into input_pipeline/tfds_data_processing.py and input_pipeline/input_pipeline.py
2. add flag enable_file_shuffling, because I don't see a way to set seed for file_shuffling when calling "train_ds_builder.as_dataset", so when it is set to true through the flag enable_data_shuffling, we don't get determinism. With the two flags, we can achieve determinism by setting enable_file_shuffling=False, enable_data_shuffling=True, data_shuffle_seed=<the same seed>
3. fix input_pipeline_test.py and rename to tfds_data_processing_test.py

convergence tested: https://pantheon.corp.google.com/kubernetes/service/us-east5/v5e-256-bodaborg/default/aireen-v5e256-0119-1503/logs?e=13802955&mods=allow_workbench_image_override&project=tpu-prod-env-multipod