### PR TITLE
Splitting kv cache - prefill

### DIFF
--- a/MaxText/common_types.py
+++ b/MaxText/common_types.py
@@ -39,6 +39,7 @@ D_KV = 'activation_kv'
 
 MODEL_MODE_AUTOREGRESSIVE = 'autoregressive'
 MODEL_MODE_PREFILL = 'prefill'
+MODEL_MODE_PREFILL_NEW = 'prefill_new'
 MODEL_MODE_TRAIN = 'train'
 
 DECODING_ACTIVE_SEQUENCE_INDICATOR = 1

--- a/MaxText/common_types.py
+++ b/MaxText/common_types.py
@@ -39,7 +39,7 @@ D_KV = 'activation_kv'
 
 MODEL_MODE_AUTOREGRESSIVE = 'autoregressive'
 MODEL_MODE_PREFILL = 'prefill'
-MODEL_MODE_PREFILL_NEW = 'prefill_new'
+MODEL_MODE_PREFILL_SPLIT = 'prefill_split'
 MODEL_MODE_TRAIN = 'train'
 
 DECODING_ACTIVE_SEQUENCE_INDICATOR = 1

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -80,6 +80,7 @@ attention: 'flash' # Supported attention: dot_product, flash, gpu_flash_xla, gpu
 # Combine matmuls for QKV and MLP
 fused_qkv: False
 fused_mlp: False
+combined_kv_cache: True
 
 record_internal_nn_metrics: 0
 

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -77,6 +77,7 @@ class DecoderLayer(nn.Module):
       num_kv_heads=cfg.num_kv_heads,
       head_dim=cfg.head_dim,
       max_target_length=cfg.max_target_length,
+      max_prefill_predict_length=cfg.max_prefill_predict_length,
       attention_kernel=cfg.attention,
       mesh=mesh,
       dtype=cfg.dtype,

--- a/MaxText/tests/attention_test.py
+++ b/MaxText/tests/attention_test.py
@@ -50,6 +50,7 @@ class AttentionTest(unittest.TestCase):
     self.num_kv_heads = self.cfg.num_kv_heads
     self.num_query_heads = self.cfg.num_query_heads
     self.max_target_length = self.cfg.max_target_length
+    self.max_prefill_predict_length = self.cfg.max_prefill_predict_length
     self.head_dim = self.cfg.head_dim
     self.embed_dim = self.cfg.base_emb_dim
     self.dtype = self.cfg.dtype
@@ -60,8 +61,9 @@ class AttentionTest(unittest.TestCase):
         num_kv_heads=self.num_kv_heads,
         head_dim=self.head_dim,
         max_target_length=self.max_target_length,
+        max_prefill_predict_length=self.max_prefill_predict_length,
         mesh=self.mesh,
-        attention_kernel = "dot_product",
+        attention_kernel="dot_product",
         dtype=self.dtype,
         dropout_rate=self.cfg.dropout_rate,
         name='self_attention',
@@ -195,6 +197,7 @@ class AttentionTest(unittest.TestCase):
         num_kv_heads=self.num_kv_heads,
         head_dim=self.head_dim,
         max_target_length=self.max_target_length,
+        max_prefill_predict_length=self.max_prefill_predict_length,
         mesh=self.mesh,
         attention_kernel = "flash",
         dtype=self.dtype,
@@ -239,6 +242,7 @@ class AttentionTest(unittest.TestCase):
         num_kv_heads=1,
         head_dim=self.head_dim,
         max_target_length=self.max_target_length,
+        max_prefill_predict_length=self.max_prefill_predict_length,
         mesh=self.mesh,
         attention_kernel = "dot_product",
         dtype=self.dtype,


### PR DESCRIPTION
First part of changes to split the kv cache into prefill and AR portions. This code just takes care of the prefill portion and defaults to not being used for the time being. When the AR portion of the kv cache split is complete we can remove the newly added `combined_kv_cache` boolean config entry and the related `if/else` statements. 