### PR TITLE
Add validation for overwritten keys

### DIFF
--- a/MaxText/configs/models/llama2-7b.yml
+++ b/MaxText/configs/models/llama2-7b.yml
@@ -23,7 +23,6 @@ head_dim: 128
 mlp_activations: ["silu","linear"]
 vocab_size: 32000
 enable_dropout: False
-attention: "dot_product"
 vocab_relative_path: "tokenizer.llama2"
 logits_via_embedding: False
 rms_norm_epsilon: 1.0e-5

--- a/MaxText/configs/models/mistral-7b.yml
+++ b/MaxText/configs/models/mistral-7b.yml
@@ -23,7 +23,6 @@ head_dim: 128
 mlp_activations: ["silu","linear"]
 vocab_size: 32000
 enable_dropout: False
-attention: "dot_product"
 vocab_relative_path: "tokenizer.model"
 logits_via_embedding: False
 rms_norm_epsilon: 1.0e-5


### PR DESCRIPTION
# Description

Add validation for overwritten keys between keys from env/command line and model:
* Move core logic to `_update_from_env_and_command_line` helper function
* Add `validate_no_keys_overwritten_twice` helper function 
* Other small changes: delete unused vars

# Tests
If there is an overwritten keys, i.e. `attention=dot_product` in the unit test, we will get error:

```
Traceback (most recent call last):
  File "/home/ranran/maxtext/MaxText/decode.py", line 274, in <module>
    app.run(main)
  File "/home/ranran/.local/lib/python3.10/site-packages/absl/app.py", line 308, in run
    _run_main(main, args)
  File "/home/ranran/.local/lib/python3.10/site-packages/absl/app.py", line 254, in _run_main
    sys.exit(main(argv))
  File "/home/ranran/maxtext/MaxText/decode.py", line 266, in main
    pyconfig.initialize(argv)
  File "/home/ranran/maxtext/MaxText/pyconfig.py", line 300, in initialize
    _config = _HyperParameters(argv, **kwargs)
  File "/home/ranran/maxtext/MaxText/pyconfig.py", line 159, in __init__
    validate_overwritten_keys(keys_from_env_and_command_line, keys_from_model)
  File "/home/ranran/maxtext/MaxText/pyconfig.py", line 75, in validate_overwritten_keys
    raise ValueError(
ValueError: Keys ['attention'] are overwritten from both the model and the environment/command line. This isn't allowed.
```
