### PR TITLE
Initialize SummaryWriter only for a single host

### DIFF
--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -37,6 +37,7 @@ from flax.linen import partitioning as nn_partitioning
 import optax
 import os
 from typing import Tuple
+from tensorboardX import writer
 
 from google.cloud import storage
 
@@ -75,6 +76,13 @@ def activate_profiler(config):
 def deactivate_profiler(config):
   if config.enable_profiler and (config.upload_all_profiler_results or jax.process_index() == 0):
     jax.profiler.stop_trace()
+
+def initialize_summary_writer(config):
+  return writer.SummaryWriter(config.tensorboard_dir) if jax.process_index() == 0 else None
+
+def close_summary_writer(summary_writer):
+  if jax.process_index() == 0:
+    summary_writer.close()
 
 def _prepare_metrics_for_json(metrics, step, run_name):
   """Converts metric dictionary into json supported types (e.g. float)"""

--- a/MaxText/standalone_checkpointer.py
+++ b/MaxText/standalone_checkpointer.py
@@ -85,7 +85,7 @@ def checkpoint_loop(config, state=None):
         if jax.process_index() == 0:
           max_logging.log(f"STANDALONE CHECKPOINTER : Checkpoint saved in {end_time - start_time} ,step {step}, on host 0")
 
-  writer.close()
+  max_utils.close_summary_writer(writer)
   return state
 
 def main(argv: Sequence[str]) -> None:

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -31,7 +31,6 @@ from flax.linen import partitioning as nn_partitioning
 import jax
 import numpy as np
 import optax
-from tensorboardX import SummaryWriter
 
 import checkpointing
 import max_utils
@@ -220,7 +219,7 @@ def setup_mesh_and_model(config):
   """
 
   init_rng = random.PRNGKey(config.init_weights_seed)
-  writer = SummaryWriter(config.tensorboard_dir)
+  writer = max_utils.initialize_summary_writer(config)
   checkpoint_manager = checkpointing.create_orbax_checkpoint_manager(
       config.checkpoint_dir,
       config.enable_checkpointing,
@@ -349,7 +348,7 @@ def train_loop(config, state=None):
     if step == last_profiling_step:
       max_utils.deactivate_profiler(config)
 
-  writer.close()
+  max_utils.close_summary_writer(writer)
   return state
 
 def main(argv: Sequence[str]) -> None:


### PR DESCRIPTION
Initialize `SummaryWriter` only for a single host. Initializing a writer on all hosts causes each host to create a tfevents file in GCS although only one is actually writing metrics.