### PR TITLE
Migrate Llama2, Mistral, and Gamma to XL ML

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -102,18 +102,6 @@ jobs:
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
         'bash end_to_end/test_generate_param_only_checkpoint.sh -r runner_$(date +%Y-%m-%d-%H-%M) -o gs://runner-maxtext-logs -d gs://maxtext-dataset -i 4'
-    - name: Test llama2 operations
-      run: |
-        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
-        'bash end_to_end/llama_load_and_test.sh'
-    - name: Test mistral operations
-      run: |
-        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
-        'bash end_to_end/mistral_load_and_test.sh'
-    - name: Test Gamma decode.py
-      run: |
-        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
-        'bash end_to_end/test_gamma.sh'
   
   # IF YOU MODIFY THIS, YOU SHOULD ALSO ADD CORRESPONDING MODICATIONS TO 'tpu' job
   gpu:

--- a/end_to_end/test_gamma.sh
+++ b/end_to_end/test_gamma.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -e
 idx=$(date +%Y-%m-%d-%H-%M)
 # convert 2.5B checkpoint

--- a/end_to_end/test_llama2.sh
+++ b/end_to_end/test_llama2.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -e
 idx=$(date +%Y-%m-%d-%H-%M)
 

--- a/end_to_end/test_mistral.sh
+++ b/end_to_end/test_mistral.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 set -e
 idx=$(date +%Y-%m-%d-%H-%M)
 


### PR DESCRIPTION
# Description

MaxText tests for Llama2, Mistral, and Gamma:
* Remove tests from unit tests
* This PR needs to be done along with this PR in XL ML repo - [PR](https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/82)
* Other small changes, i.e. rename the files to be consistent

# Test

* Successful run for three models on both stable and nightly on Airflow: [link](https://screenshot.googleplex.com/3DBMBFEaMgXyz2A)

