### PR TITLE
Run standalone dataloader and checkpointer on CPUs.

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -89,11 +89,11 @@ jobs:
     - name: Test standalone_dataloader.py
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
-        'python3 MaxText/standalone_dataloader.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M) base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset steps=100 enable_checkpointing=false'
+        'python3 MaxText/standalone_dataloader.py MaxText/configs/base.yml run_name=standalone_dataloader_$(date +%Y-%m-%d-%H-%M) base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset steps=100 enable_checkpointing=false'
     - name: Test standalone_checkpointer.py
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
-        'python3 MaxText/standalone_checkpointer.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M) base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset steps=200 checkpoint_period=50 enable_checkpointing=True async_checkpointing=False'
+        'python3 MaxText/standalone_checkpointer.py MaxText/configs/base.yml run_name=standalone_checkpointer_$(date +%Y-%m-%d-%H-%M) base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset steps=200 checkpoint_period=50 enable_checkpointing=True async_checkpointing=False'
     - name: Test int8_training
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -95,6 +95,9 @@ base_output_directory: ""
 # Jax cache directory
 jax_cache_dir: "~/jax_cache"
 
+# Hardware
+hardware: 'tpu' # Supported hardware types are 'tpu', 'gpu' and 'cpu'
+
 # Parallelism
 mesh_axes: ['data', 'fsdp', 'sequence', 'tensor', 'autoregressive']
 logical_axis_rules: [

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -97,7 +97,7 @@ class _HyperParameters():
     return args_dict
 
   def _update_from_env_and_command_line(self, raw_keys, raw_data_from_yaml, argv, **kwargs) -> list[str]:
-    ''' Update model config from environemnt and command line
+    ''' Update model config from environment and command line
     '''
     raw_data_from_cmd_line = self._load_kwargs(argv, **kwargs)
     updated_keys = []
@@ -169,8 +169,7 @@ class _HyperParameters():
     '''Transformations between the config data and configs used at runtime'''
 
     # We initialize the jax distributed system here because it must be done before device backend is initialized.
-    if raw_keys["enable_checkpointing"] and raw_keys["async_checkpointing"] and raw_keys["compile_topology_num_slices"]==-1:
-      max_utils.initialize_jax_distributed_system()
+    max_utils.maybe_initialize_jax_distributed_system(raw_keys)
 
     if raw_keys["run_name"] == "":
       raw_keys["run_name"] = os.environ.get("JOBSET_NAME") #using XPK default

--- a/MaxText/standalone_dataloader.py
+++ b/MaxText/standalone_dataloader.py
@@ -27,21 +27,14 @@ from absl import app
 import numpy as np
 
 import pyconfig
-from jax.sharding import Mesh
-import max_utils
 from train import validate_train_config, get_first_step, load_next_batch, setup_train_loop
-
-from jax.experimental.compilation_cache import compilation_cache as cc
 
 
 def data_load_loop(config, state=None):
   """Main data loader loop.
     Loads batches of data for each training step.
   """
-  _, _, _, _, _, _, _, data_iterator, state = setup_train_loop(config)
-
-  devices_array = max_utils.create_device_mesh(config)
-  mesh = Mesh(devices_array, config.mesh_axes)
+  _, _, _, _, _, mesh, _, data_iterator, state = setup_train_loop(config)
   example_batch = None
 
   start = datetime.datetime.now()
@@ -50,25 +43,25 @@ def data_load_loop(config, state=None):
   jax.block_until_ready(example_batch)
   first_end = datetime.datetime.now()
   time_to_load_first_batch = first_end-start
-  max_logging.log(f"First step completed in {time_to_load_first_batch} seconds")
+  if jax.process_index() == 0:
+    max_logging.log(f"STANDALONE DATALOADER : First step completed in {time_to_load_first_batch} seconds, on host 0")
 
   for _ in np.arange(start_step+1, config.steps):
     example_batch = load_next_batch(data_iterator, example_batch, config, mesh)
 
   jax.block_until_ready(example_batch) # wait until the last batch is read
   end = datetime.datetime.now()
-  max_logging.log(f"{config.steps} batches loaded in {end-start} seconds, on host {jax.process_index()}")
+  if jax.process_index() == 0:
+    max_logging.log(f"STANDALONE DATALOADER : {config.steps} batches loaded in {end-start} seconds, on host 0")
   return state
 
 
 def main(argv: Sequence[str]) -> None:
-  jax.config.update('jax_default_prng_impl', 'unsafe_rbg')
-  os.environ["LIBTPU_INIT_ARGS"] = os.environ.get("LIBTPU_INIT_ARGS","") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
+  jax.config.update('jax_cpu_enable_gloo_collectives', True)
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
   pyconfig.initialize(argv)
   config = pyconfig.config
   validate_train_config(config)
-  cc.initialize_cache(os.path.expanduser(config.jax_cache_dir))
   max_logging.log(f"Found {jax.device_count()} devices.")
   max_logging.log(f"Found {jax.process_count()} processes.")
   max_logging.log(f"Found {jax.devices()} devices.")


### PR DESCRIPTION
- Introducing JAX distributed initialize for CPU multihost environment. (Thanks to @priyanka-ganesha for finding the required CPU settings.)
- Added retry logic to ensure processes connect to the coordinator once it is up.
- Updating the workflow test names.
- Fixing bug in standalone_dataloader where Mesh was being initialized twice. Bug was introduced by commit http://shortn/_Q5ITxrra63 .
- Introducing 'hint_hardware' in the config.
