### PR TITLE
Update v5p configs

### DIFF
--- a/MaxText/configs/v5p/256b.sh
+++ b/MaxText/configs/v5p/256b.sh
@@ -29,7 +29,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
-    steps=20 per_device_batch_size=2 enable_checkpointing=false\
+    steps=20 per_device_batch_size=1 enable_checkpointing=false\
     enable_profiler=false remat_policy=minimal global_parameter_scale=256\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=8\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\

--- a/MaxText/configs/v5p/32b.sh
+++ b/MaxText/configs/v5p/32b.sh
@@ -29,7 +29,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
-    steps=30 per_device_batch_size=8 enable_checkpointing=false\
+    steps=30 per_device_batch_size=7 enable_checkpointing=false\
     enable_profiler=false remat_policy=minimal global_parameter_scale=32\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=4\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\

--- a/MaxText/configs/v5p/512b.sh
+++ b/MaxText/configs/v5p/512b.sh
@@ -31,7 +31,7 @@ export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gathe
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
     steps=20 per_device_batch_size=2 enable_checkpointing=false\
     enable_profiler=false remat_policy=full global_parameter_scale=512\
-    ici_fsdp_parallelism=-1 ici_tensor_parallelism=16\
+    ici_fsdp_parallelism=-1 ici_tensor_parallelism=8\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\
     dataset_type=synthetic gcs_metrics=true attention='flash' int8_training=false


### PR DESCRIPTION
Updating v5p configs as 32B on 2xv5p-128s and 256B on 2xv5p-1024s fail with out of memory errors - might be due to recent compiler changes. 512B on v5p-1024s fails with mesh creation related errors.
Perf numbers will need to be updated accordingly as we get additional capacity.

b/323298666