### PR TITLE
Fix Google SDK installation.

### DIFF
--- a/maxtext_dependencies.Dockerfile
+++ b/maxtext_dependencies.Dockerfile
@@ -7,12 +7,8 @@ RUN apt-get update && apt-get install -y curl gnupg git
 # Install dependencies for adjusting network rto
 RUN apt-get update && apt-get install -y iproute2 ethtool lsof
 
-# Add the Google Cloud SDK package repository
-RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
-
 # Install the Google Cloud SDK
-RUN apt-get update && apt-get install -y google-cloud-sdk
+RUN curl -sSL https://sdk.cloud.google.com | bash
 
 # Set the default Python version to 3.10
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.10 1


### PR DESCRIPTION
Github runner tests are failing due to "Install dependencies" step where Google Cloud SDK is being installed.