### PR TITLE
refactor maxtext checkpointing and integrate with grain

### DIFF
--- a/MaxText/checkpointing.py
+++ b/MaxText/checkpointing.py
@@ -16,21 +16,22 @@
 
 """Create an Orbax CheckpointManager with specified (Async or not) Checkpointer."""
 
+from typing import Optional
 from etils import epath
-import jax
-from orbax import checkpoint
-from orbax.checkpoint.checkpoint_manager import CheckpointManager, CheckpointManagerOptions, Checkpointer, AsyncCheckpointer
-from orbax.checkpoint import type_handlers
+from orbax.checkpoint.checkpoint_manager import CheckpointManager, CheckpointManagerOptions
+import orbax.checkpoint
+import grain.python as grain
 
 import max_logging
-
+from multihost_dataloading import MultiHostDataLoadIterator
 from flax.training import train_state
 
 def create_orbax_checkpoint_manager(
     checkpoint_dir: str,
     enable_checkpointing: bool,
     use_async: bool,
-    save_interval_steps: int
+    save_interval_steps: int,
+    dataset_type: Optional[str] = 'c4'
 ):
   """Returns specified Orbax (async or not) CheckpointManager or None if checkpointing is disabled."""
   if not enable_checkpointing:
@@ -38,17 +39,21 @@ def create_orbax_checkpoint_manager(
     return None
   max_logging.log("Creating checkpoint manager...")
   p = epath.Path(checkpoint_dir)
-  if use_async:
-    checkpointer = AsyncCheckpointer(checkpoint.PyTreeCheckpointHandler())
+
+  if dataset_type=='c4-array_record':
+    item_names = ('default', 'iter')
+  elif dataset_type=='c4':
+    item_names = ('default',)
   else:
-    checkpointer = Checkpointer(checkpoint.PyTreeCheckpointHandler())
+    raise ValueError(f"Unknown dataset_type {dataset_type}. dataset_type must be c4, c4-array_record or synthetic")
 
   mngr = CheckpointManager(
       p,
-      checkpointer,
-      options=CheckpointManagerOptions(
+      item_names = item_names,
+      options = CheckpointManagerOptions(
           create=True,
-          save_interval_steps=save_interval_steps
+          save_interval_steps=save_interval_steps,
+          enable_async_checkpointing=use_async,
       )
   )
   max_logging.log("Checkpoint manager created!")
@@ -56,11 +61,11 @@ def create_orbax_checkpoint_manager(
 
 
 def load_state_if_possible(checkpoint_manager: CheckpointManager,
+                           data_iterator: MultiHostDataLoadIterator,
                            load_parameters_from_path: str,
                            load_full_state_from_path: str,
                            abstract_unboxed_pre_state: train_state.TrainState,
-                           mesh,
-                           state_mesh_annotations):
+                           dataset_type: Optional[str] = 'c4'):
   """Loads TrainState as possible from the inputs.
 
   Args:
@@ -82,47 +87,46 @@ def load_state_if_possible(checkpoint_manager: CheckpointManager,
      At most one will be non-None. Both can be None if neither checkpoint is
      set.
   """
-  def map_to_pspec(data, pspec):
-    if isinstance(data, (jax.Array, jax.ShapeDtypeStruct)) \
-          and pspec is not None:
-      return type_handlers.ArrayRestoreArgs(mesh=mesh, mesh_axes=pspec, dtype = data.dtype)
-    else:
-      return type_handlers.RestoreArgs()
-  restore_args = jax.tree_util.tree_map(map_to_pspec,
-                                        abstract_unboxed_pre_state,
-                                        state_mesh_annotations)
 
   if checkpoint_manager is not None:
     max_logging.log("checkpoint manager exists so trying to load this run's existing checkpoint")
 
     latest_step = checkpoint_manager.latest_step()
     if latest_step is not None:
-      max_logging.log(f"restoring state from this run's directory latest step \
+      max_logging.log(f"restoring from this run's directory latest step \
           {latest_step}")
-      return checkpoint_manager.restore(latest_step, abstract_unboxed_pre_state,
-                                        {"restore_args" : restore_args}), None
-    else:
-      max_logging.log("failed to find preexisting checkpoint for this run")
+      if dataset_type == 'c4-array_record':
+        return checkpoint_manager.restore(latest_step,
+                                      args=orbax.checkpoint.args.Composite(
+                                      default=orbax.checkpoint.args.StandardRestore(abstract_unboxed_pre_state),
+                                      iter=grain.PyGrainCheckpointRestore(data_iterator.local_iterator)
+                                    )), None
+      elif dataset_type == 'c4':
+        return checkpoint_manager.restore(latest_step,
+                                      args=orbax.checkpoint.args.Composite(
+                                      default=orbax.checkpoint.args.StandardRestore(abstract_unboxed_pre_state),
+                                    )), None
+      else:
+        raise ValueError(f"Unknown dataset_type {dataset_type}. dataset_type must be c4, c4-array_record or synthetic")
 
   if load_parameters_from_path != "":
     max_logging.log(f"restoring params from {load_parameters_from_path=}")
     p = epath.Path(load_parameters_from_path)
-    checkpointer = Checkpointer(checkpoint.PyTreeCheckpointHandler())
-    restore_args_param_train_state = train_state.TrainState(step = restore_args.step, params = restore_args.params,\
-                                                            tx=None,  opt_state = {}, apply_fn=None) # type: ignore
-    abstract_param_train_state = train_state.TrainState(step = abstract_unboxed_pre_state.step,\
-                                                        params = abstract_unboxed_pre_state.params,\
-                                                        tx=None,opt_state = {}, apply_fn=None) # type: ignore
-    full_restored_state = checkpointer.restore(p, item = abstract_param_train_state,\
-                                               restore_args = restore_args_param_train_state)
-    return None, full_restored_state.params
+    ckptr = orbax.checkpoint.PyTreeCheckpointer()
+    metadata = ckptr.metadata(p)
+    restore_args = orbax.checkpoint.checkpoint_utils.construct_restore_args(metadata)
+    restored = ckptr.restore(p, item = {'params': metadata['params']}, transforms={},
+                             restore_args = {'params': restore_args['params']})
+
+    return None, restored['params']
+
   elif load_full_state_from_path != "":
     max_logging.log(f"restoring full state from {load_full_state_from_path=}")
     p = epath.Path(load_full_state_from_path)
-    checkpointer = Checkpointer(checkpoint.PyTreeCheckpointHandler())
-    return checkpointer.restore(p,
-                                item=abstract_unboxed_pre_state,
-                                restore_args=restore_args), None
+    ckptr = orbax.checkpoint.StandardCheckpointer()
+    restored = ckptr.restore(p, args=orbax.checkpoint.args.StandardRestore(abstract_unboxed_pre_state))
+    return  {'default': restored, 'iter': None}, None
+
   else:
     max_logging.log("No existing checkpoints found, not restoring checkpoint.")
     return None, None

--- a/MaxText/convert_gamma_chkpt.py
+++ b/MaxText/convert_gamma_chkpt.py
@@ -30,6 +30,7 @@ import max_logging
 import orbax
 
 import checkpointing
+from train import save_checkpoint
 
 Params = dict[str, Any]
 
@@ -166,7 +167,7 @@ def main(raw_args=None) -> None:
   )
 
   if checkpoint_manager is not None:
-    if checkpoint_manager.save(0, state_new):
+    if save_checkpoint(checkpoint_manager, 0, state_new):
       max_logging.log("saved a checkpoint at step 0")
     # Upon preemption, exit when and only when all ongoing saves are complete.
     if checkpoint_manager.reached_preemption(0):

--- a/MaxText/convert_gpt3_ckpt_from_paxml.py
+++ b/MaxText/convert_gpt3_ckpt_from_paxml.py
@@ -49,6 +49,7 @@ import jax
 import gc
 import max_logging
 from psutil import Process
+from train import save_checkpoint
 import argparse
 
 def fmt_size(num_bytes: int) -> str:
@@ -99,7 +100,7 @@ def convert(paxml_ckpt_path, maxtext_model_name, base_output_directory, run_name
     cfg.checkpoint_period,
   )
 
-  state, _ = max_utils.setup_training_state(model, tx, cfg, init_rng, mesh, checkpoint_manager)
+  state, _, _ = max_utils.setup_training_state(model, None, tx, cfg, init_rng, mesh, checkpoint_manager)
   max_logging.log("start")
   check_memory()
 
@@ -203,7 +204,7 @@ def convert(paxml_ckpt_path, maxtext_model_name, base_output_directory, run_name
   max_logging.log("converted state finished")
   check_memory()
 
-  if checkpoint_manager.save(converted_state.step, converted_state):
+  if save_checkpoint(checkpoint_manager, converted_state.step, converted_state):
     max_logging.log(f"saved a checkpoint at step {converted_state.step}")
   # Upon preemption, exit when and only when all ongoing saves are complete.
   if checkpoint_manager.reached_preemption(converted_state.step):

--- a/MaxText/generate_param_only_checkpoint.py
+++ b/MaxText/generate_param_only_checkpoint.py
@@ -38,6 +38,7 @@ from jax.sharding import Mesh
 from jax import random
 from typing import Sequence
 from layers import models
+from train import save_checkpoint
 
 Transformer = models.Transformer
 
@@ -78,8 +79,8 @@ def _read_train_checkpoint(config, checkpoint_manager, mesh):
   rng = random.PRNGKey(0)
   learning_rate_schedule = max_utils.create_learning_rate_schedule(config)
   tx = optimizers.get_optimizer(config, learning_rate_schedule)
-  state, state_mesh_notations = max_utils.setup_training_state(
-    model, tx, config, rng, mesh, checkpoint_manager
+  state, state_mesh_notations, _ = max_utils.setup_training_state(
+    model, None, tx, config, rng, mesh, checkpoint_manager
   )
   num_params = max_utils.calculate_num_params_from_pytree(state.params)
   max_logging.log(f"In input checkpoint Number of model params={num_params/10**9:.3f} billion")
@@ -90,7 +91,7 @@ def _save_decode_checkpoint(config, state, checkpoint_manager):
   with jax.spmd_mode('allow_all'):
     decode_state = max_utils.init_decode_state(None, jax.tree_map(lambda x : x.astype(jax.numpy.bfloat16), state.params))
   if checkpoint_manager is not None:
-    if checkpoint_manager.save(0, decode_state):
+    if save_checkpoint(checkpoint_manager, 0, decode_state):
       max_logging.log(f"saved an decode checkpoint at {config.checkpoint_dir}")
     # Upon preemption, exit when and only when all ongoing saves are complete.
     if checkpoint_manager.reached_preemption(0):

--- a/MaxText/llama_or_mistral_ckpt.py
+++ b/MaxText/llama_or_mistral_ckpt.py
@@ -38,6 +38,7 @@ import jax
 import jax.numpy as jnp
 from flax.training import train_state
 import max_logging
+from train import save_checkpoint
 import torch
 import sys
 
@@ -374,7 +375,7 @@ def convert(base_model_path, maxtext_model_path, model_size):
   )
 
   if checkpoint_manager is not None:
-    if checkpoint_manager.save(step_number_to_save_new_ckpt, state_new):
+    if save_checkpoint(checkpoint_manager, step_number_to_save_new_ckpt, state_new):
       max_logging.log(
           f"saved a checkpoint at step {step_number_to_save_new_ckpt}")
     # Upon preemption, exit when and only when all ongoing saves are complete.

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -310,7 +310,7 @@ def init_training_state(apply_fn, params, tx):
     )
   return state
 
-def init_initial_state(model, tx, config, is_training, key):
+def init_initial_state(model, params, tx, config, is_training, key):
   """
   We pass in "static" objects like model, tx, config as JAX compares them by
   object hash, and instantiating them inside causes pjit top-level annotations
@@ -325,19 +325,24 @@ def init_initial_state(model, tx, config, is_training, key):
   model_vars = model.init({'params': key, 'dropout': key, 'aqt': key},
                           jnp.ones(input_shape, dtype=jnp.int32),
                           jnp.ones(input_shape, dtype=jnp.int32))
+  if not params:
+    params = model_vars['params']
   if is_training:
-    return init_training_state(model.apply, model_vars['params'], tx)
-  return init_decode_state(model.apply, model_vars['params'])
+    return init_training_state(model.apply, params, tx)
+  return init_decode_state(model.apply, params)
 
 def setup_decode_state(model, config, rng, mesh, checkpoint_manager):
   is_training = False
-  return setup_initial_state(model, None, config, rng, mesh, checkpoint_manager, is_training)
+  state, state_mesh_annotations, _ = setup_initial_state(model, None, None, config,
+                                                         rng, mesh, checkpoint_manager,
+                                                         is_training)
+  return state, state_mesh_annotations
 
-def setup_training_state(model, tx, config, rng, mesh, checkpoint_manager):
+def setup_training_state(model, data_iterator, tx, config, rng, mesh, checkpoint_manager):
   is_training = True
-  return setup_initial_state(model, tx, config, rng, mesh, checkpoint_manager, is_training)
+  return setup_initial_state(model, data_iterator, tx, config, rng, mesh, checkpoint_manager, is_training)
 
-def setup_initial_state(model, tx, config, rng, mesh, checkpoint_manager, is_training=True):
+def setup_initial_state(model, data_iterator, tx, config, rng, mesh, checkpoint_manager, is_training=True):
   """ We initialize the model and optimizer state, and optionally load from a
   checkpoint as necessary.
 
@@ -355,32 +360,32 @@ def setup_initial_state(model, tx, config, rng, mesh, checkpoint_manager, is_tra
     state_mesh_annotations: the mesh annotations for the train state
   """
 
-  unboxed_abstract_state, state_mesh_annotations = get_abstract_state(model, tx, config, rng, mesh, is_training)
+  unboxed_abstract_state, state_mesh_annotations, state_mesh_shardings = get_abstract_state(model, tx, config,
+                                                                                            rng, mesh, is_training)
 
   # Initialization
   with nn_partitioning.axis_rules(config.logical_axis_rules):
-    state, raw_params = checkpointing.load_state_if_possible(checkpoint_manager,
+    restored, raw_params = checkpointing.load_state_if_possible(checkpoint_manager,
+                                                data_iterator,
                                                 config.load_parameters_path,
                                                 config.load_full_state_path,
                                                 unboxed_abstract_state,
-                                                mesh,
-                                                state_mesh_annotations)
+                                                config.dataset_type)
 
-    state_mesh_shardings = jax.tree_map(
-        lambda p: jax.sharding.NamedSharding(mesh, p), state_mesh_annotations)
-    if not state:
-      init_state_partial = functools.partial(init_initial_state, model, tx, config, is_training)
+    if restored:
+      if 'iter' in restored and restored['iter'] is not None:
+        data_iterator.local_iterator = restored['iter']
+      state = restored['default']
+    else:
+      init_state_partial = functools.partial(init_initial_state, model, raw_params, tx, config, is_training)
       state = jax.jit(
           init_state_partial,
           in_shardings=None,
           out_shardings=state_mesh_shardings
       )(rng)
-      if raw_params: # If we loaded a partial state, we need to merge it.
-        state = state.replace(params = raw_params)
-    raw_params = None
 
   state = unbox_logicallypartioned(state)
-  return state, state_mesh_annotations
+  return state, state_mesh_annotations, data_iterator
 
 
 # Learning Rate Schedule
@@ -508,16 +513,26 @@ cross_entropy_with_logits.defvjp(_cross_entropy_with_logits_fwd,
 
 def get_abstract_state(model, tx, config, rng, mesh, is_training=True):
   """ Get a shaped abstraction of the state (including optimizer)"""
-  init_state_partial = functools.partial(init_initial_state, model, tx,
-                                              config, is_training)
-  abstract_state = jax.eval_shape(init_state_partial, rng)
-  state_logical_annotations = nn.get_partition_spec(abstract_state)
-  unboxed_abstract_state = unbox_logicallypartioned(abstract_state)
+  init_state_partial = functools.partial(init_initial_state, model, None, tx, config, is_training)
 
+  abstract_state = jax.eval_shape(init_state_partial, rng)
+
+  state_logical_annotations = nn.get_partition_spec(abstract_state)
+
+  state_mesh_shardings = nn.logical_to_mesh_sharding(state_logical_annotations, mesh,
+                                                     config.logical_axis_rules)
+
+  abstract_sharded_state = jax.jit(
+      init_state_partial,
+      in_shardings=None,
+      out_shardings=state_mesh_shardings
+  ).eval_shape(rng)
+
+  unboxed_abstract_sharded_state = unbox_logicallypartioned(abstract_sharded_state)
   # Initialization
   with mesh, nn_partitioning.axis_rules(config.logical_axis_rules):
     state_mesh_annotations = nn.logical_to_mesh(state_logical_annotations)
-  return unboxed_abstract_state, state_mesh_annotations
+  return unboxed_abstract_sharded_state, state_mesh_annotations, state_mesh_shardings
 
 def get_kv_cache_annotations(model, config, rng, mesh):
   """ Get a shaped abstraction of the state (including optimizer)"""

--- a/MaxText/standalone_checkpointer.py
+++ b/MaxText/standalone_checkpointer.py
@@ -33,7 +33,7 @@ import checkpointing
 import max_utils
 import max_logging
 import pyconfig
-from train import setup_mesh_and_model, get_first_step, validate_train_config
+from train import setup_mesh_and_model, get_first_step, validate_train_config, save_checkpoint
 
 from layers import models
 
@@ -50,25 +50,24 @@ def checkpoint_loop(config, state=None):
   """
   init_rng, writer, checkpoint_manager, mesh, model, _, tx = setup_mesh_and_model(config)
 
-  unboxed_abstract_state, state_mesh_annotations = max_utils.get_abstract_state(model, tx,
+  unboxed_abstract_state, _, _ = max_utils.get_abstract_state(model, tx,
                                                 config, init_rng, mesh, is_training=True)
   # A barrier to sync all hosts before starting to restore checkpoint
   jax.experimental.multihost_utils.sync_global_devices("Barrier before load")
   checkpoint_load_start = datetime.datetime.now()
   with nn_partitioning.axis_rules(config.logical_axis_rules):
     state, _ = checkpointing.load_state_if_possible(checkpoint_manager,
+                                                None,
                                                 config.load_parameters_path,
                                                 config.load_full_state_path,
-                                                unboxed_abstract_state,
-                                                mesh,
-                                                state_mesh_annotations)
+                                                unboxed_abstract_state)
   jax.block_until_ready(state)
   checkpoint_load_end = datetime.datetime.now()
   if state is not None: # Checkpoint was available for restore
     if jax.process_index() == 0:
       max_logging.log(f"STANDALONE CHECKPOINTER : Checkpoint restored in : {checkpoint_load_end - checkpoint_load_start}")
   else: # Checkpoint was unavailable, state needs to be initialized
-    state, state_mesh_annotations = max_utils.setup_training_state(model,
+    state, _, _ = max_utils.setup_training_state(model, None,
           tx, config, init_rng, mesh, checkpoint_manager)
 
   start_step = get_first_step(state) # this is the start_step for training
@@ -77,7 +76,7 @@ def checkpoint_loop(config, state=None):
       start_time = datetime.datetime.now()
       # A barrier to sync all hosts before starting to save checkpoint
       jax.experimental.multihost_utils.sync_global_devices("Barrier before save")
-      if checkpoint_manager.save(step, state):
+      if save_checkpoint(checkpoint_manager, step, state):
         checkpoint_manager.wait_until_finished()
         end_time = datetime.datetime.now()
         if jax.process_index() == 0:

--- a/MaxText/tests/grain_data_processing_test.py
+++ b/MaxText/tests/grain_data_processing_test.py
@@ -26,10 +26,6 @@ import unittest
 import pyconfig
 from input_pipeline import _grain_data_processing
 
-if os.path.exists("../../gcsfuse"):
-    os.system("fusermount -u ../../gcsfuse")
-    os.rmdir("../../gcsfuse")
-# os.mkdir("../gcsfuse")
 exit_code = os.system("bash ../setup_gcsfuse.sh DATASET_GCS_BUCKET=maxtext-dataset MOUNT_PATH=../../gcsfuse")
 if exit_code != 0:
     raise ValueError(f"Running setup_gcsfuse.sh failed with exit code: {exit_code}")

--- a/MaxText/tests/max_utils_test.py
+++ b/MaxText/tests/max_utils_test.py
@@ -119,8 +119,8 @@ class MaxUtilsInitTransformerState(unittest.TestCase):
   def test_setup_initial_state(self):
     rng = random.PRNGKey(0)
     tx = optax.adam(learning_rate=0.001)
-    state, _ = max_utils.setup_initial_state(
-      self.model, tx, self.config, rng, self.mesh, None)
+    state, _, _ = max_utils.setup_initial_state(
+      self.model, None, tx, self.config, rng, self.mesh, None)
     self.assertEqual(state.tx, tx)
     self.assertNotEqual(state.opt_state, {})
 

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -29,9 +29,11 @@ from typing import Sequence
 from absl import app
 from flax import linen as nn
 from flax.linen import partitioning as nn_partitioning
+import grain.python as grain
 import jax
 import numpy as np
 import optax
+import orbax.checkpoint
 
 import checkpointing
 import max_utils
@@ -159,6 +161,18 @@ def write_metrics_to_tensorboard(writer, metrics, step, config):
       )
       writer.flush()
 
+def save_checkpoint(checkpoint_manager, step, state, dataset_type='c4', data_iterator=None):
+  """Wrapper for saving checkpoint"""
+  if dataset_type == 'c4':
+    return checkpoint_manager.save(step, args=orbax.checkpoint.args.Composite(
+                                                    default=orbax.checkpoint.args.StandardSave(state)))
+  elif dataset_type == 'c4-array_record':
+    return checkpoint_manager.save(step, args=orbax.checkpoint.args.Composite(
+                                                    default=orbax.checkpoint.args.StandardSave(state),
+                                                    iter=grain.PyGrainCheckpointSave(data_iterator.local_iterator)
+                                                    ))
+  else:
+    raise ValueError(f"Unknown dataset_type {dataset_type}. dataset_type must be c4, c4-array_record or synthetic")
 # -----------------------------------------------------------------------------
 # Top-level Functions
 # -----------------------------------------------------------------------------
@@ -297,6 +311,7 @@ def setup_mesh_and_model(config):
       config.enable_checkpointing,
       config.async_checkpointing,
       config.checkpoint_period,
+      config.dataset_type,
   )
   # Mesh definition
   devices_array = max_utils.create_device_mesh(config)
@@ -331,7 +346,7 @@ def setup_train_loop(config):
   init_rng, writer, checkpoint_manager, mesh, model, learning_rate_schedule, tx = setup_mesh_and_model(config)
   data_iterator, eval_data_iterator, _ = create_data_iterator_with_tokenizer(config, mesh)
 
-  state, state_mesh_annotations = max_utils.setup_training_state(model,
+  state, state_mesh_annotations, data_iterator = max_utils.setup_training_state(model, data_iterator,
           tx, config, init_rng, mesh, checkpoint_manager)
 
   return ( init_rng, writer, checkpoint_manager, state_mesh_annotations, model,
@@ -427,8 +442,9 @@ def train_loop(config, state=None):
     last_step_completion = new_time
 
     if checkpoint_manager is not None:
-      if checkpoint_manager.save(step, state):
+      if save_checkpoint(checkpoint_manager, step, state, config.dataset_type, data_iterator):
         max_logging.log(f"saved a checkpoint at step {step}")
+
       # Upon preemption, exit when and only when all ongoing saves are complete.
       if checkpoint_manager.reached_preemption(step):
         checkpoint_manager.wait_until_finished()
@@ -456,6 +472,8 @@ def train_loop(config, state=None):
     if step == last_profiling_step:
       max_utils.deactivate_profiler(config)
 
+  if checkpoint_manager is not None:
+    checkpoint_manager.wait_until_finished()
   write_metrics(writer, local_metrics_file, running_gcs_metrics, metrics, config.steps - 1, config) # final step metrics
   max_utils.close_summary_writer(writer)
   return state

--- a/MaxText/train_compile.py
+++ b/MaxText/train_compile.py
@@ -77,7 +77,7 @@ def get_shaped_inputs(topology_mesh, config):
   shaped_rng = jax.ShapeDtypeStruct(example_rng.shape, example_rng.dtype)
 
   # Shaped state
-  abstract_state, state_mesh_annotations =  max_utils.get_abstract_state(model, tx, config, example_rng, topology_mesh)
+  abstract_state, state_mesh_annotations, _ =  max_utils.get_abstract_state(model, tx, config, example_rng, topology_mesh)
 
   # Shaped batch
   shaped_batch = input_pipeline_interface.get_shaped_batch(config)

--- a/end_to_end/eval_assert.py
+++ b/end_to_end/eval_assert.py
@@ -63,7 +63,7 @@ def test_final_loss(metrics_file, target_loss):
     assert avg_final_loss < target_loss
     print('Final loss test passed.')
 
-def test_checkpointing(metrics_file, target):
+def test_checkpointing(metrics_file, target, dataset_type):
   """Asserts over loss values from loaded checkpoint"""
   metrics_file_saved = 'saved_' + metrics_file
   metrics_file_restored = 'restored_' + metrics_file
@@ -76,7 +76,12 @@ def test_checkpointing(metrics_file, target):
     # step in saved checkpoint to loss of first step in restored checkpoint
     print("saved loss: ", saved_loss)
     print("restored loss: ", restored_loss)
-    assert isclose(saved_loss, restored_loss, rel_tol=0.1)
+    if dataset_type=='c4':
+      assert isclose(saved_loss, restored_loss, rel_tol=0.1)
+    elif dataset_type=='c4-array_record':
+      assert saved_loss==restored_loss
+    else:
+      raise ValueError(f"Unknown dataset_type {dataset_type}. dataset_type must be c4, c4-array_record or synthetic")
     print('checkpointing test passed.')
 
 def test_determinism(metrics_file, target):
@@ -109,7 +114,9 @@ def main(argv: Sequence[str]) -> None:
   if test_scenario == 'metrics_average':
     assert_metric_average(*test_vars)
   elif test_scenario == 'checkpoint_save_restore':
-    test_checkpointing(*test_vars)
+    test_checkpointing(*test_vars, dataset_type='c4')
+  elif test_scenario == 'grain_checkpoint_save_restore':
+    test_checkpointing(*test_vars, dataset_type='c4-array_record')
   elif test_scenario == 'determinism':
     test_determinism(*test_vars)
   elif test_scenario == 'vocab_creation':

--- a/end_to_end/test_checkpointing.sh
+++ b/end_to_end/test_checkpointing.sh
@@ -1,22 +1,40 @@
 #!/bin/bash
 set -e
 
-RUN_NAME=${1}-${4}-$(date +%Y-%m-%d-%H)
+RUN_NAME=${1}-${4}-$(date +%Y-%m-%d-%H-%M)
 OUTPUT_PATH=${2}
 DATASET_PATH=${3}
 COLLECT_STACK_TRACE=${4}
+DATASET_TYPE=${5}
+EVAL_METRICS=checkpoint_save_restore
+
+if [ "$DATASET_TYPE" == "c4-array_record" ]
+then
+    EVAL_METRICS=grain_checkpoint_save_restore
+    echo "Using c4-array_record dataset type"
+    echo "Mounting $DATASET_PATH to /tmp/gcsfuse/"
+    bash setup_gcsfuse.sh DATASET_GCS_BUCKET=$DATASET_PATH MOUNT_PATH=/tmp/gcsfuse/
+    DATASET_PATH=/tmp/gcsfuse/
+    CMD_DATA=" dataset_type=c4-array_record dataset_name=array-record/c4/en/3.0.1 eval_dataset_name=array-record/c4/en/3.0.1"
+fi
 
 #Train
-python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME steps=501\
-    metrics_file='saved_metrics.txt' checkpoint_period=20 base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH\
-    collect_stack_trace=$COLLECT_STACK_TRACE
+CMD1="python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME steps=7\
+    metrics_file=saved_metrics.txt checkpoint_period=5 base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH\
+    collect_stack_trace=$COLLECT_STACK_TRACE"
+CMD1+=$CMD_DATA
 
+CMD2="python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME steps=7\
+    metrics_file=restored_metrics.txt base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH\
+    collect_stack_trace=$COLLECT_STACK_TRACE"
+CMD2+=$CMD_DATA
+
+
+$CMD1
 # Wait for first train to finish
 process_id=$!
 wait $process_id
 
-python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME steps=502\
-    metrics_file='restored_metrics.txt' base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH\
-    collect_stack_trace=$COLLECT_STACK_TRACE
+$CMD2
 
-python3 end_to_end/eval_assert.py checkpoint_save_restore metrics.txt learning/loss
+python3 end_to_end/eval_assert.py $EVAL_METRICS metrics.txt learning/loss

--- a/end_to_end/test_convergence_1b_params.sh
+++ b/end_to_end/test_convergence_1b_params.sh
@@ -23,22 +23,22 @@ for ARGUMENT in "$@"; do
     export "$KEY"="$VALUE"
 done
 
+if [ "$DATASET_TYPE" == "c4-array_record" ]
+then
+    EVAL_METRICS=grain_checkpoint_save_restore
+    echo "Using c4-array_record dataset type"
+    echo "Mounting $DATASET_PATH to /tmp/gcsfuse/"
+    bash setup_gcsfuse.sh DATASET_GCS_BUCKET=$DATASET_PATH MOUNT_PATH=/tmp/gcsfuse/
+    DATASET_PATH=/tmp/gcsfuse/
+    CMD_DATA=" dataset_type=c4-array_record dataset_name=array-record/c4/en/3.0.1 eval_dataset_name=array-record/c4/en/3.0.1"
+fi
+
 TRAIN_CMD="python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
         steps=20400 per_device_batch_size=8.0 learning_rate=3e-4 enable_checkpointing=false \
         max_target_length=2048 global_parameter_scale=1 \
         enable_profiler=false metrics_file=metrics.txt base_output_directory=$OUTPUT_PATH\
         dataset_path=$DATASET_PATH log_period=150 enable_data_shuffling=false"
-
-if [ -n "$DATASET_TYPE" ] && [ "$DATASET_TYPE" == "c4-array_record" ]
-then
-    echo "Using c4-array_record dataset type"
-    if [ ! -d $DATASET_PATH ]
-    then
-        echo "$DATASET_PATH does not exist, or is not a local path. Please use setup_gcsfuse.sh to mount your GCS bucket when DATASET_TYPE is c4-array_record"
-        exit
-    fi
-    TRAIN_CMD+=" dataset_type=c4-array_record dataset_name=array-record/c4/en/3.0.1 eval_dataset_name=array-record/c4/en/3.0.1"
-fi
+TRAIN_CMD+=$CMD_DATA
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"

--- a/end_to_end/test_determinism.sh
+++ b/end_to_end/test_determinism.sh
@@ -4,13 +4,28 @@ set -e
 RUN_NAME=${1}_$(date +%Y-%m-%d-%H)
 OUTPUT_PATH=${2}
 DATASET_PATH=${3}
+DATASET_TYPE=${4}
 
+if [ "$DATASET_TYPE" == "c4-array_record" ]
+then
+    EVAL_METRICS=grain_checkpoint_save_restore
+    echo "Using c4-array_record dataset type"
+    echo "Mounting $DATASET_PATH to /tmp/gcsfuse/"
+    bash setup_gcsfuse.sh DATASET_GCS_BUCKET=$DATASET_PATH MOUNT_PATH=/tmp/gcsfuse/
+    DATASET_PATH=/tmp/gcsfuse/
+    CMD_DATA=" dataset_type=c4-array_record dataset_name=array-record/c4/en/3.0.1 eval_dataset_name=array-record/c4/en/3.0.1"
+fi
 
 #Train
-python3 MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME}_1 steps=5 metrics_file='run_1_metrics.txt'\
-    enable_checkpointing=False enable_data_shuffling=True enable_dropout=False base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH
+CMD1="python3 MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME}_1 steps=5 metrics_file='run_1_metrics.txt'\
+    enable_checkpointing=False enable_data_shuffling=True enable_dropout=False base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH"
+CMD1+=$CMD_DATA
 
-python3 MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME}_2 steps=5 metrics_file='run_2_metrics.txt'\
-    enable_checkpointing=False enable_data_shuffling=True enable_dropout=False base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH
 
+CMD2="python3 MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME}_2 steps=5 metrics_file='run_2_metrics.txt'\
+    enable_checkpointing=False enable_data_shuffling=True enable_dropout=False base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH"
+CMD2+=$CMD_DATA
+
+$CMD1
+$CMD2
 python3 end_to_end/eval_assert.py determinism metrics.txt learning/loss 

--- a/setup_gcsfuse.sh
+++ b/setup_gcsfuse.sh
@@ -31,9 +31,9 @@ if [[ -z ${DATASET_GCS_BUCKET} || -z ${MOUNT_PATH} ]]; then
   exit 1
 fi
 
-if [[ $GCS_BUCKET == gs://* ]] ; then
-    echo "Remove gs:// from GCS bucket name"
-    exit 1
+if [[ "$DATASET_GCS_BUCKET" =~ gs:\/\/ ]] ; then
+    DATASET_GCS_BUCKET="${DATASET_GCS_BUCKET/gs:\/\//}"
+    echo "Removed gs:// from GCS bucket name, GCS bucket is $DATASET_GCS_BUCKET"
 fi
 
 if ! command -v sudo &> /dev/null ; then
@@ -50,6 +50,11 @@ if ! command -v gcsfuse &> /dev/null ; then
   curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
   sudo apt-get update -y && sudo apt-get -y install gcsfuse
   sudo rm -rf /var/lib/apt/lists/*
+fi
+
+if [[ -d ${MOUNT_PATH} ]]; then
+  echo "$MOUNT_PATH exists, removing..."
+  fusermount -u $MOUNT_PATH || rm -rf $MOUNT_PATH
 fi
 
 mkdir -p $MOUNT_PATH


### PR DESCRIPTION
1. refactor checkpointing code to use orbax's new API, this is necessary since Grain has already migrated and the old API will be deprecated May 1st, 2024
2. Add grain support - when user set dataset_type to 'c4-array_record', the checkpoint folder will have a iter folder (contains index) in addition to the default folder.
3. A tfds run can be resumed using Grain - The new ckpts will have the iter folder
4. A Grain run can be resumed using tfds - Only model state in the default folder will be loaded
5. Fixed a bug for async ckpt: process get terminated before async ckpt finished, often results in the last ckpt being partial. Adding checkpoint_manager.wait_until_finished() at the end of train_loop() fixed it. 