### PR TITLE
[Nina] load ckpt according to config weight_dtype

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -134,3 +134,11 @@ jobs:
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
         'python3 MaxText/train.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M) base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset quantization=int8 steps=2 enable_checkpointing=false attention=dot_product'
+    - name: Test decode.py
+      run: |
+        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
+        'python3 MaxText/decode.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M) base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset steps=2 ici_tensor_parallelism=4 attention=dot_product enable_checkpointing=false max_target_length=128 per_device_batch_size=1'
+    - name: Test decode.py with per_device_batch_size < 1
+      run: |
+        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
+        'python3 MaxText/decode.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M) base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset steps=2 ici_tensor_parallelism=4 attention=dot_product enable_checkpointing=false max_target_length=128 per_device_batch_size=.25'

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -63,6 +63,7 @@ decoder_block: "llama2" # which style of DecoderBlock to use.
 # Global parameter scale needs to be a power of 2. If you want finer grained control of the model sizes
 # then you should explicitly set base_embed_dim, base_num_query_heads, base_num_kv_heads,
 # base_mlp_dim, base_num_decoder_layers and/or head_dim.
+weight_dtype: float32
 global_parameter_scale: 1
 base_emb_dim: 2048
 base_num_query_heads: 16

--- a/MaxText/layers/embeddings.py
+++ b/MaxText/layers/embeddings.py
@@ -56,7 +56,7 @@ class Embed(nn.Module):
         'embedding',
         with_logical_partitioning(self.embedding_init, ('vocab', 'embed')),
         (self.num_embeddings, self.features),
-        jnp.float32,
+        self.config.weight_dtype,
     )
 
   def __call__(self, inputs: Array) -> Array:

--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -118,7 +118,7 @@ class DenseGeneral(nn.Module):
         'kernel',
         nn.with_logical_partitioning(self.kernel_init, self.kernel_axes),
         kernel_shape,
-        jnp.float32,
+        self.dtype,
         kernel_in_axis,
         kernel_out_axis,
     )

--- a/MaxText/layers/normalizations.py
+++ b/MaxText/layers/normalizations.py
@@ -42,7 +42,7 @@ class RMSNorm(nn.Module):
         'scale',
         nn.with_logical_partitioning(self.scale_init, self.kernel_axes),
         (features,),
-        jnp.float32,
+        self.dtype,
     )
 
     scale = jnp.asarray(scale, self.dtype)


### PR DESCRIPTION
Instead of loading ckpt as float32, data type is decided by config.dype.
Add Unit tests for gpu inference.
change s/decode_iter to ms/decode_iter
change rng