### PR TITLE
fix gpt3 e2e test

### DIFF
--- a/MaxText/configs/models/gpt3-52k.yml
+++ b/MaxText/configs/models/gpt3-52k.yml
@@ -37,3 +37,4 @@ adam_b1: 0.9
 adam_b2: 0.95
 adam_eps: 1.e-8
 adam_weight_decay: 0.1
+attention: "dot_product"  # head_dim 8 is too small for splash/flash attention

--- a/MaxText/tests/gpt3_test.py
+++ b/MaxText/tests/gpt3_test.py
@@ -60,7 +60,6 @@ class GPT3(unittest.TestCase):
     super().setUp()
     pyconfig.initialize(
       [sys.argv[0], 'configs/base.yml'],
-      attention="dot_product",
       run_name='test',
       enable_checkpointing=False,
       model_name='gpt3-52k',


### PR DESCRIPTION
GPT3-52k is failing due to splash attention not working on that baby head size of 8. Disable splash attention by default.

- [x] local test passed and verified. 