### PR TITLE
Add Llama2/Mistral/Mixtral test instructions for external users

### DIFF
--- a/end_to_end/llama_finetuning_test.sh
+++ b/end_to_end/llama_finetuning_test.sh
@@ -1,3 +1,9 @@
+#!/bin/bash
+
+# This script is designed for internal use within Google. External users can adapt it by:
+#  - Updating GCS paths (gs://) to your accessible locations.
+#  - Using the checkpoint generated from train.py or available one in open source (https://llama.meta.com/llama-downloads/).
+
 set -e
 idx=$(date +%Y-%m-%d-%H-%M)
 

--- a/end_to_end/test_llama2.sh
+++ b/end_to_end/test_llama2.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# This script is designed for internal use within Google. External users can adapt it by:
+#  - Updating GCS paths (gs://) to your accessible locations.
+#  - Using the checkpoint generated from train.py or available one in open source (https://llama.meta.com/llama-downloads/).
+
 set -e
 idx=$(date +%Y-%m-%d-%H-%M)
 
@@ -8,7 +13,6 @@ export M_BASE_OUTPUT_DIRECTORY=gs://runner-maxtext-logs
 export M_DATASET_PATH=gs://maxtext-dataset
 export M_ASYNC_CHECKPOINTING=false
 
-#TODO(internal bug -- migrate to XLML)
 #pip install torch
 #gsutil cp -r gs://maxtext-llama/llama2-7b/meta-ckpt /tmp/
 #python3 MaxText/llama_or_mistral_ckpt.py --base-model-path /tmp/meta-ckpt --model-size llama2-7b --maxtext-model-path gs://maxtext-llama/test/${idx}/decode-ckpt-maxtext/
@@ -16,10 +20,10 @@ export M_ASYNC_CHECKPOINTING=false
 # Load after directly from parameter checkpoint
 python3 MaxText/decode.py MaxText/configs/base.yml load_parameters_path=${base_ckpt_path} run_name=runner_direct_${idx} per_device_batch_size=1 model_name='llama2-7b' ici_tensor_parallelism=4 max_prefill_predict_length=4  max_target_length=16 prompt="I love to" autoregressive_decode_assert="read. I love to write. I love to share." attention=dot_product
 
-#TODO(Training with Llama is not complete)
+# Training
 python3 MaxText/train.py MaxText/configs/base.yml load_parameters_path=${base_ckpt_path} run_name=runner_${idx}  per_device_batch_size=1 model_name='llama2-7b' ici_tensor_parallelism=4 steps=10 max_target_length=1024 per_device_batch_size=1
 
-# generate parameter checkpoint from Llama's "fine-tuning" run
+# Generate parameter checkpoint from Llama's "fine-tuning" run
 unset M_LOAD_PARAMETERS_PATH
 export PARAMETER_CHECKPOINT_RUN=generate_param_only_checkpoint_${idx}
 python3 MaxText/generate_param_only_checkpoint.py MaxText/configs/base.yml load_full_state_path=${M_BASE_OUTPUT_DIRECTORY}/runner_${idx}/checkpoints/0/default run_name=${PARAMETER_CHECKPOINT_RUN} model_name='llama2-7b' force_unroll=true

--- a/end_to_end/test_mistral.sh
+++ b/end_to_end/test_mistral.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# This script is designed for internal use within Google. External users can adapt it by:
+#  - Updating GCS paths (gs://) to your accessible locations.
+#  - Using the checkpoint generated from train.py or available one in open source (i.e. https://files.mistral-7b-v0-1.mistral.ai/mistral-7B-v0.1.tar).
+
 set -e
 idx=$(date +%Y-%m-%d-%H-%M)
 
@@ -11,6 +16,6 @@ export M_ASYNC_CHECKPOINTING=false
 pip3 install torch
 gsutil -m cp -r gs://maxtext-external/mistral-7B-v0.1 /tmp
 python3 MaxText/llama_or_mistral_ckpt.py --base-model-path /tmp/mistral-7B-v0.1 --model-size mistral-7b --maxtext-model-path gs://maxtext-mistral/test/${idx}/decode-ckpt-maxtext/
-python3 MaxText/decode.py MaxText/configs/base.yml load_parameters_path=gs://maxtext-mistral/test/${idx}/decode-ckpt-maxtext/0/default run_name=runner_direct_${idx} per_device_batch_size=1 model_name='mistral-7b' tokenizer_path=gs://maxtext-external/mistral-7B-v0.1/tokenizer.model ici_tensor_parallelism=4 max_prefill_predict_length=4  max_target_length=16 prompt="I love to" autoregressive_decode_assert="read. I love to read about the Bible. I love" attention=dot_product
+python3 MaxText/decode.py MaxText/configs/base.yml load_parameters_path=gs://maxtext-mistral/test/${idx}/decode-ckpt-maxtext/0/default run_name=runner_direct_${idx} per_device_batch_size=1 model_name='mistral-7b' tokenizer_path=gs://maxtext-external/mistral-7B-v0.1/tokenizer.mistral ici_tensor_parallelism=4 max_prefill_predict_length=4 max_target_length=16 prompt="I love to" autoregressive_decode_assert="read. I love to read about the Bible. I love" attention=dot_product
 
 # TODO(ranran): add training and fine-tuning tests

--- a/end_to_end/test_mixtral.sh
+++ b/end_to_end/test_mixtral.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+
+# This script is designed for internal use within Google. External users can adapt it by:
+#  - Updating GCS paths (gs://) to your accessible locations.
+#  - Using the checkpoint generated from train.py or available one in open source (i.e. https://files.mixtral-8x7b-v0-1.mistral.ai/Mixtral-8x7B-v0.1-Instruct.tar).
+
 set -e
 idx=$(date +%Y-%m-%d-%H-%M)
 
@@ -11,4 +16,6 @@ export M_ASYNC_CHECKPOINTING=false
 pip3 install torch
 gsutil -m cp -r gs://maxtext-external/mixtral-8x7B-v0.1-Instruct /tmp
 python3 MaxText/llama_or_mistral_ckpt.py --base-model-path /tmp/mixtral-8x7B-v0.1-Instruct --model-size mixtral-8x7b --maxtext-model-path gs://maxtext-mixtral/test/${idx}/decode-ckpt-maxtext/
-python3 MaxText/decode.py MaxText/configs/base.yml load_parameters_path=gs://maxtext-external/mixtral-8x7B-v0.1-Instruct-maxtext/0/default run_name=runner_direct_${idx} per_device_batch_size=1 model_name=mixtral-8x7b tokenizer_path=gs://maxtext-external/mixtral-8x7B-v0.1-Instruct/tokenizer.model ici_tensor_parallelism=4 ici_fsdp_parallelism=16 max_prefill_predict_length=11 max_target_length=28 prompt="[INST] I love to [/INST]" autoregressive_decode_assert="That's great to hear! I love to learn new things and explore different interests" attention=dot_product
+python3 MaxText/decode.py MaxText/configs/base.yml load_parameters_path=gs://maxtext-external/mixtral-8x7B-v0.1-Instruct-maxtext/0/default run_name=runner_direct_${idx} per_device_batch_size=1 model_name=mixtral-8x7b tokenizer_path=gs://maxtext-external/mixtral-8x7B-v0.1-Instruct/tokenizer.mistral ici_tensor_parallelism=4 ici_fsdp_parallelism=16 max_prefill_predict_length=11 max_target_length=28 prompt="[INST] I love to [/INST]" autoregressive_decode_assert="That's great to hear! I love to learn new things and explore different interests" attention=dot_product
+
+# TODO(ranran): add training and fine-tuning tests


### PR DESCRIPTION
# Description

Add Llama2/Mistral/Mixtral test instructions for external users to address [issues/412](https://github.com/google/maxtext/issues/412):
* with a small change to suffix of tokenizer_path 