### PR TITLE
Split the flag up to the first equal sign only.

### DIFF
--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -94,7 +94,7 @@ class _HyperParameters():
           raise ValueError(f"We received env `{environment_var}` but it isn't all uppercase.")
 
   def _load_kwargs(self, argv: list[str], **kwargs):
-    args_dict = dict(a.split("=") for a in argv[2:])
+    args_dict = dict(a.split("=", 1) for a in argv[2:])
     args_dict.update(kwargs)
     return args_dict
 


### PR DESCRIPTION
This allows the flag value to contain "=", which can sometimes happen for paths, e.g. `base_output_directory=/some/path=abc`.