### PR TITLE
Fix metrics filename for determinism test

### DIFF
--- a/end_to_end/test_determinism.sh
+++ b/end_to_end/test_determinism.sh
@@ -17,12 +17,12 @@ then
 fi
 
 #Train
-CMD1="python3 MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME}_1 steps=5 metrics_file='run_1_metrics.txt'\
+CMD1="python3 MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME}_1 steps=5 metrics_file=run_1_metrics.txt\
     enable_checkpointing=False enable_data_shuffling=True enable_dropout=False base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH"
 CMD1+=$CMD_DATA
 
 
-CMD2="python3 MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME}_2 steps=5 metrics_file='run_2_metrics.txt'\
+CMD2="python3 MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME}_2 steps=5 metrics_file=run_2_metrics.txt\
     enable_checkpointing=False enable_data_shuffling=True enable_dropout=False base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH"
 CMD2+=$CMD_DATA
 


### PR DESCRIPTION
Fix metrics filename for determinism test

Looks like a refactor-ish [change](https://github.com/google/maxtext/commit/c9b15991236d84dd8cfba4686a2f725c3adc9b1b#diff-1b4ff7109ddfff9f2034b374f408e3268732f4cc7e337f66f067cbef40073343) modified how quotes are parsed - the metrics file is saved as <'run1_metrics.txt'> instead of <run1_metrics.txt>, simple fix to remove quotes

Internally tracked: b/326598512