### PR TITLE
Fix weight dtypes

### DIFF
--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -701,6 +701,7 @@ class Attention(nn.Module):
       mesh: Mesh, device mesh
       attention_kernel: str, guidance on if we should use an attention kernel
       dtype: the dtype of the computation.
+      weight_dtype: the dtype of the weights.
       max_target_length: maximum target length
       max_prefill_predict_length: size of the maximum prefill
       dropout_rate: dropout rate
@@ -720,6 +721,7 @@ class Attention(nn.Module):
   mesh: Mesh
   attention_kernel: str
   dtype: DType = jnp.float32
+  weight_dtype: DType = jnp.float32
   max_prefill_predict_length: int = -1
   dropout_rate: float = 0.
   kernel_init: NdInitializer = nd_dense_init(1.0, 'fan_in', 'normal')
@@ -750,6 +752,7 @@ class Attention(nn.Module):
       kernel_init=query_init,
       kernel_axes=('embed', 'heads', 'kv'),
       dtype=self.dtype,
+      weight_dtype=self.weight_dtype,
       name='query',
       quant=self.quant)(inputs_q)
     return query_proj
@@ -777,6 +780,7 @@ class Attention(nn.Module):
         kernel_init=self.kernel_init,
         kernel_axes=('embed', 'heads', 'kv'),
         dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
         name=proj_name,
         quant=self.quant)(inputs_kv)
     return kv_proj
@@ -790,6 +794,7 @@ class Attention(nn.Module):
       kernel_init=self.kernel_init,
         kernel_axes=('embed', 'qkv', 'heads', 'kv'),
         dtype=self.dtype,
+        weight_dtype=self.weight_dtype,
         name=proj_name,
         quant=self.quant)(inputs)
     query, key, value = qkv_proj[:,:,0,...], qkv_proj[:,:,1,...], qkv_proj[:,:,2,...]
@@ -802,6 +807,7 @@ class Attention(nn.Module):
       kernel_init=self.kernel_init,
       kernel_axes=('heads', 'kv', 'embed'),
       dtype=self.dtype,
+      weight_dtype=self.weight_dtype,
       name='out',
       quant=self.quant)(out)
     return out_proj

--- a/MaxText/layers/gemma.py
+++ b/MaxText/layers/gemma.py
@@ -72,6 +72,7 @@ class GemmaDecoderLayer(nn.Module):
     # inputs: embedded inputs to the decoder with shape [batch, length, emb_dim]
     lnx = RMSNorm(
         dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
         name='pre_self_attention_norm',
         kernel_axes=('embed',))(inputs)
 
@@ -88,6 +89,7 @@ class GemmaDecoderLayer(nn.Module):
       attention_kernel=cfg.attention,
       mesh=mesh,
       dtype=cfg.dtype,
+      weight_dtype=cfg.weight_dtype,
       dropout_rate=cfg.dropout_rate,
       name='self_attention',
       float32_qk_product = True,
@@ -109,6 +111,7 @@ class GemmaDecoderLayer(nn.Module):
     residual = attention_lnx
     attn_output = RMSNorm(
         dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
         name='pre_ffw_norm',
         kernel_axes=('embed',))(attention_lnx)
 
@@ -118,6 +121,7 @@ class GemmaDecoderLayer(nn.Module):
         activations=cfg.mlp_activations,
         intermediate_dropout_rate=cfg.dropout_rate,
         dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
         name='mlp',
         config=cfg,
         quant=self.quant,

--- a/MaxText/layers/llama2.py
+++ b/MaxText/layers/llama2.py
@@ -71,6 +71,7 @@ class LlamaDecoderLayer(nn.Module):
 
     lnx_rms = models.RMSNorm(
         dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
         name='pre_self_attention_layer_norm',
         kernel_axes=('embed',),
         epsilon=cfg.normalization_layer_epsilon,
@@ -91,6 +92,7 @@ class LlamaDecoderLayer(nn.Module):
       attention_kernel=cfg.attention,
       mesh=mesh,
       dtype=cfg.dtype,
+      weight_dtype=cfg.weight_dtype,
       dropout_rate=cfg.dropout_rate,
       name='self_attention',
       quant=self.quant)
@@ -110,7 +112,10 @@ class LlamaDecoderLayer(nn.Module):
 
     # Fully Connected
     hidden_states = models.RMSNorm(
-        dtype=cfg.dtype, name='post_self_attention_layer_norm', kernel_axes=('embed',),
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        name='post_self_attention_layer_norm',
+        kernel_axes=('embed',),
         epsilon=cfg.normalization_layer_epsilon,
         )(intermediate_inputs)
     hidden_states = nn.with_logical_constraint(hidden_states, ('activation_batch', 'activation_length', 'activation_embed'))
@@ -121,6 +126,7 @@ class LlamaDecoderLayer(nn.Module):
         activations=cfg.mlp_activations,
         intermediate_dropout_rate=cfg.dropout_rate,
         dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
         name='mlp',
         config=cfg,
         quant=self.quant,

--- a/MaxText/layers/mistral.py
+++ b/MaxText/layers/mistral.py
@@ -71,6 +71,7 @@ class MistralDecoderLayer(nn.Module):
 
     lnx_rms = models.RMSNorm(
         dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
         name='pre_self_attention_layer_norm',
         kernel_axes=('embed',),
         epsilon=cfg.normalization_layer_epsilon
@@ -91,6 +92,7 @@ class MistralDecoderLayer(nn.Module):
       attention_kernel=cfg.attention,
       mesh=mesh,
       dtype=cfg.dtype,
+      weight_dtype=cfg.weight_dtype,
       dropout_rate=cfg.dropout_rate,
       name='self_attention',
       quant=self.quant)
@@ -110,7 +112,10 @@ class MistralDecoderLayer(nn.Module):
 
     # Fully Connected
     hidden_states = models.RMSNorm(
-        dtype=cfg.dtype, name='post_self_attention_layer_norm', kernel_axes=('embed',),
+        dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
+        name='post_self_attention_layer_norm',
+        kernel_axes=('embed',),
         epsilon=cfg.normalization_layer_epsilon,
         )(intermediate_inputs)
     hidden_states = nn.with_logical_constraint(hidden_states, ('activation_batch', 'activation_length', 'activation_embed'))
@@ -129,6 +134,7 @@ class MistralDecoderLayer(nn.Module):
 
         gate_logits = linears.DenseGeneral(
             cfg.num_experts,
+            weight_dtype=cfg.weight_dtype,
             dtype=cfg.dtype,
             kernel_init=initializers.nd_dense_init(
                 1.0, 'fan_in', 'truncated_normal'),
@@ -153,6 +159,7 @@ class MistralDecoderLayer(nn.Module):
                 activations=cfg.mlp_activations,
                 intermediate_dropout_rate=cfg.dropout_rate,
                 dtype=cfg.dtype,
+                weight_dtype=cfg.weight_dtype,
                 name=f'mlp_{k}',
                 config=cfg,
             )(hidden_states, deterministic=deterministic)
@@ -167,6 +174,7 @@ class MistralDecoderLayer(nn.Module):
             activations=cfg.mlp_activations,
             intermediate_dropout_rate=cfg.dropout_rate,
             dtype=cfg.dtype,
+            weight_dtype=cfg.weight_dtype,
             name='mlp',
             config=cfg,
         )(hidden_states, deterministic=deterministic)

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -69,6 +69,7 @@ class DecoderLayer(nn.Module):
     # inputs: embedded inputs to the decoder with shape [batch, length, emb_dim]
     lnx = RMSNorm(
         dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
         name='pre_self_attention_norm',
         epsilon=cfg.normalization_layer_epsilon,
         kernel_axes=('embed',))(inputs)
@@ -85,6 +86,7 @@ class DecoderLayer(nn.Module):
       attention_kernel=cfg.attention,
       mesh=mesh,
       dtype=cfg.dtype,
+      weight_dtype=cfg.weight_dtype,
       dropout_rate=cfg.dropout_rate,
       name='self_attention',
       quant=self.quant)
@@ -108,6 +110,7 @@ class DecoderLayer(nn.Module):
         activations=cfg.mlp_activations,
         intermediate_dropout_rate=cfg.dropout_rate,
         dtype=cfg.dtype,
+        weight_dtype=cfg.weight_dtype,
         name='mlp',
         config=cfg,
         quant=self.quant,
@@ -280,6 +283,7 @@ class Decoder(nn.Module):
 
     y = self.get_norm_layer()(
       dtype=cfg.dtype,
+      weight_dtype=cfg.weight_dtype,
       name='decoder_norm',
       epsilon=cfg.normalization_layer_epsilon,
       kernel_axes=('embed',),
@@ -298,6 +302,7 @@ class Decoder(nn.Module):
     else:
       logits = linears.DenseGeneral(
           cfg.vocab_size,
+          weight_dtype=cfg.weight_dtype,
           dtype=jnp.float32 if cfg.logits_dot_in_fp32 else cfg.dtype,  # for logit training stability
           kernel_axes=('embed', 'vocab'),
           name='logits_dense')(y) # We do not quantize the logits matmul.

--- a/MaxText/layers/normalizations.py
+++ b/MaxText/layers/normalizations.py
@@ -28,6 +28,7 @@ class RMSNorm(nn.Module):
   """RMS normalization."""
   epsilon: float = 1e-6
   dtype: Any = jnp.float32
+  weight_dtype: Any = jnp.float32
   kernel_axes: Tuple[str, ...] = ()
   scale_init: Initializer = nn.initializers.ones
 
@@ -42,7 +43,7 @@ class RMSNorm(nn.Module):
         'scale',
         nn.with_logical_partitioning(self.scale_init, self.kernel_axes),
         (features,),
-        self.dtype,
+        self.weight_dtype,
     )
 
     scale = jnp.asarray(scale, self.dtype)

--- a/MaxText/tests/weight_dtypes_test.py
+++ b/MaxText/tests/weight_dtypes_test.py
@@ -1,0 +1,66 @@
+"""
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+""" Test that all weights are expected dtype (default float32) """
+import unittest
+from absl.testing import absltest
+
+import pyconfig
+
+import optimizers
+from layers import models
+from layers import quantizations
+import max_utils
+import jax
+from jax.sharding import Mesh
+import jax.numpy as jnp
+
+Transformer = models.Transformer
+
+class WeightDtypes(unittest.TestCase):
+    """Test that all weights are expected dtype (default float32) """
+
+    def get_weights(self, argv):
+        """ Gets model weights """
+
+        # Setup necessary inputs to build a model state
+        pyconfig.initialize(argv)
+        config = pyconfig.config
+        quant = quantizations.configure_quantization(config)
+        devices_array = max_utils.create_device_mesh(config)
+        mesh = Mesh(devices_array, config.mesh_axes)
+        model = Transformer(config, mesh, quant=quant)
+        learning_rate_schedule = max_utils.create_learning_rate_schedule(config)
+        tx = optimizers.get_optimizer(config, learning_rate_schedule)
+        _, example_rng = jax.random.split(jax.random.PRNGKey(0), 2)
+
+        abstract_state, _ , _ =  max_utils.get_abstract_state(model, tx, config, example_rng, mesh)
+        return abstract_state.params
+
+    def assert_weights_are_dtype(self, weights, expected_dtype):
+        jax.tree_util.tree_map_with_path(lambda x,y: self.assertEqual(y.dtype, expected_dtype), weights)
+
+    def test_default_float32(self):
+        argv = [None, "configs/base.yml", "enable_checkpointing=False"]
+        weights = self.get_weights(argv)
+        self.assert_weights_are_dtype(weights, jnp.float32)
+
+    def test_set_bf16(self):
+        argv = [None, "configs/base.yml", "enable_checkpointing=False", "weight_dtype=bfloat16"]
+        weights = self.get_weights(argv)
+        self.assert_weights_are_dtype(weights, jnp.bfloat16)
+
+


### PR DESCRIPTION
Fix weight dytpes to float32

Weight dtypes inadvertently changed to bf16 in PR #417 

Ran convergence test and confirmed familiar good convergence of 2.48 after 20k steps [XPK logs](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22tpu-prod-env-multipod%22%0Aresource.labels.location%3D%22us-central2%22%0Aresource.labels.cluster_name%3D%22v4-bodaborg%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Fjobset_sigs_k8s_io%2Fjobset-name%3D%22mattdavidow-fix-dtype-a2%22%20severity%3E%3DDEFAULT%0Aresource.labels.pod_name%3D%22mattdavidow-fix-dtype-a2-slice-job-0-1-k4j7z%22;cursorTimestamp=2024-03-02T08:32:05.916493434Z;startTime=2024-03-01T23:50:42.346Z;endTime=2024-03-02T20:50:42.346351Z?e=13803378&mods=allow_workbench_image_override&project=tpu-prod-env-multipod)