### PR TITLE
Add new remat policies

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -82,7 +82,8 @@ logits_via_embedding: False
 normalize_embedding_logits: True  # whether to normlize pre-softmax logits if logits_via_embedding is true
 logits_dot_in_fp32: True  # whether to use fp32 in logits_dense or shared_embedding dot product for stability
 
-# proj, minimal, minimal_offloaded, full, or none
+# Choose 'remat_policy' between 'minimal', 'save_dot_except_mlpwi', 'save_dot_except_mlp', 'save_qkv_proj', 'minimal_offloaded' and 'full'.
+# These options offer a trade-off between speed (fastest to slowest) and HBM usage (highest to lowest)
 remat_policy: 'full'
 scan_layers: True
 param_scan_axis: 1

--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -797,6 +797,7 @@ class Attention(nn.Module):
         weight_dtype=self.weight_dtype,
         name=proj_name,
         quant=self.quant)(inputs)
+    qkv_proj = checkpoint_name(qkv_proj, 'qkv_proj')
     query, key, value = qkv_proj[:,:,0,...], qkv_proj[:,:,1,...], qkv_proj[:,:,2,...]
     return query, key, value
 
@@ -890,4 +891,5 @@ class Attention(nn.Module):
 
     # apply output projection,  output dim is set to the input dim.
     out = self.out_projection(inputs_q.shape[-1], out)
+    out = checkpoint_name(out, 'out_proj')
     return out

--- a/MaxText/layers/gpt3.py
+++ b/MaxText/layers/gpt3.py
@@ -165,6 +165,7 @@ class Gpt3MultiHeadAttention(nn.Module):
       quant=self.quant,
       use_bias=self.use_bias,
       )(inputs)
+    qkv_proj = checkpoint_name(qkv_proj, 'qkv_proj')
     query, key, value = qkv_proj[:,:,0,...], qkv_proj[:,:,1,...], qkv_proj[:,:,2,...]
     return query, key, value
 
@@ -239,6 +240,7 @@ class Gpt3MultiHeadAttention(nn.Module):
 
     # apply output projection,  output dim is set to the input dim.
     out = self.out_projection(inputs_q.shape[-1], out)
+    out = checkpoint_name(out, 'out_proj')
     return out
 
 

--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -27,6 +27,7 @@ from layers import initializers
 from layers import normalizations
 from layers import quantizations
 import numpy as np
+from jax.ad_checkpoint import checkpoint_name
 
 Array = common_types.Array
 Config = common_types.Config
@@ -233,6 +234,7 @@ class MlpBlock(nn.Module):
 
     # Take elementwise product of above intermediate activations.
     x = functools.reduce(operator.mul, activations)
+    x = checkpoint_name(x, 'mlpwi')
     # Apply dropout and final dense output projection.
     x = nn.Dropout(rate=self.intermediate_dropout_rate, broadcast_dims=(-2,))(
         x, deterministic=deterministic
@@ -250,6 +252,8 @@ class MlpBlock(nn.Module):
         quant=self.quant,
         use_bias=self.use_bias,
     )(x)
+
+    output = checkpoint_name(output, 'mlpwo')
     return output
 
 

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -220,9 +220,17 @@ class Decoder(nn.Module):
     if cfg.remat_policy != 'none':
       if cfg.remat_policy == 'minimal':
         policy = jax.checkpoint_policies.checkpoint_dots_with_no_batch_dims
-      elif cfg.remat_policy == 'proj':
+      elif cfg.remat_policy == 'save_dot_except_mlpwi':
         policy = jax.checkpoint_policies.save_only_these_names(
-            'query_proj', 'value_proj', 'key_proj'
+            'query_proj', 'value_proj', 'key_proj', 'qkv_proj', 'out_proj', 'mlpwo',
+        )
+      elif cfg.remat_policy == 'save_dot_except_mlp':
+        policy = jax.checkpoint_policies.save_only_these_names(
+            'query_proj', 'value_proj', 'key_proj', 'qkv_proj', 'out_proj',
+        )
+      elif cfg.remat_policy == 'save_qkv_proj':
+        policy = jax.checkpoint_policies.save_only_these_names(
+            'query_proj', 'value_proj', 'key_proj', 'qkv_proj',
         )
       elif cfg.remat_policy == 'minimal_offloaded':
         policy = jax.checkpoint_policies.offload_dot_with_no_batch_dims(offload_src="device", offload_dst="pinned_host")

--- a/MaxText/tests/train_compile_test.py
+++ b/MaxText/tests/train_compile_test.py
@@ -60,3 +60,39 @@ class TrainCompile(unittest.TestCase):
     train_compile_main((None, "configs/base.yml", f"compiled_trainstep_file={compiled_trainstep_file}",
       "compile_topology=v5e-256", "use_iota_embed=true", "compile_topology_num_slices=1", 
       "ici_sequence_parallelism=16", "global_parameter_scale=32", "per_device_batch_size=0.0625", "max_target_length=65536"))
+
+  @pytest.mark.tpu
+  def test_remat_save_dot_except_mlpwi(self):
+    compiled_trainstep_file='/tmp/test_remat_save_dot_except_mlpwi.pickle'
+    train_compile_main((None, "configs/base.yml", f"compiled_trainstep_file={compiled_trainstep_file}",
+      "compile_topology=v5e-256", "compile_topology_num_slices=1", "per_device_batch_size=0.125", "ici_fsdp_parallelism=16",
+      "ici_tensor_parallelism=16", "max_target_length=2048",
+      "fused_qkv=true", "fused_mlp=true", "remat_policy=save_dot_except_mlpwi",
+      "use_iota_embed=true", "global_parameter_scale=128"))
+
+  @pytest.mark.tpu
+  def test_remat_save_dot_except_mlp(self):
+    compiled_trainstep_file='/tmp/test_remat_save_dot_except_mlp.pickle'
+    train_compile_main((None, "configs/base.yml", f"compiled_trainstep_file={compiled_trainstep_file}",
+      "compile_topology=v5e-256", "compile_topology_num_slices=1", "per_device_batch_size=0.25", "ici_fsdp_parallelism=16",
+      "ici_tensor_parallelism=16", "max_target_length=2048",
+      "fused_qkv=true", "fused_mlp=true", "remat_policy=save_dot_except_mlp",
+      "use_iota_embed=true", "global_parameter_scale=128"))
+
+  @pytest.mark.tpu
+  def test_remat_save_qkv_proj(self):
+    compiled_trainstep_file='/tmp/test_remat_save_qkv_proj.pickle'
+    train_compile_main((None, "configs/base.yml", f"compiled_trainstep_file={compiled_trainstep_file}",
+      "compile_topology=v5e-256", "compile_topology_num_slices=1", "per_device_batch_size=0.375", "ici_fsdp_parallelism=16",
+      "ici_tensor_parallelism=16", "max_target_length=2048",
+      "fused_qkv=true", "fused_mlp=true", "remat_policy=save_qkv_proj",
+      "use_iota_embed=true", "global_parameter_scale=128"))
+
+  @pytest.mark.tpu
+  def test_remat_full(self):
+    compiled_trainstep_file='/tmp/test_remat_full.pickle'
+    train_compile_main((None, "configs/base.yml", f"compiled_trainstep_file={compiled_trainstep_file}",
+      "compile_topology=v5e-256", "compile_topology_num_slices=1", "per_device_batch_size=1", "ici_fsdp_parallelism=16",
+      "ici_tensor_parallelism=16", "max_target_length=2048",
+      "fused_qkv=true", "fused_mlp=true", "remat_policy=full",
+      "use_iota_embed=true", "global_parameter_scale=128"))


### PR DESCRIPTION
As titled, add new remat policies providing more granular tradeoffs between speed and HBM memory:

* [`save_dot_except_mlpwi`]: similar to [`SAVE_DOT_EXCEPT_LOGITS_FFN1` in pax](https://github.com/google/praxis/blob/77675370d1150fccda0862a0ac7d1808d4bce9bf/praxis/layers/checkpoint_policy.py#L94). The policy will remat `mlpwi` activations only. `mlpwi` activations are memory demanding, since the `intermediate_dim` is bigger than `embed_dim`.
* [`save_dot_except_mlp`]: reference to [`SAVE_DOT_FOR_MLPERF_200B` in pax](https://github.com/google/praxis/blob/77675370d1150fccda0862a0ac7d1808d4bce9bf/praxis/layers/checkpoint_policy.py#L69), which remat both `mlpwi`  and `mlpwo` activations.

Note, skipped all checkpointing strategies within `AttentionOp` like the activation of `attn_weight` and `wv_product` since the improvement from Flash Attention is dominant as pointed out by Rafi.