### PR TITLE
use apt-key for installing gcsfuse

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -27,34 +27,18 @@
 # Enable "exit immediately if any command fails" option
 set -e
 
-# Check if sudo is available
-if command -v sudo >/dev/null 2>&1; then
-    # sudo is available, use it
-    # install numactl for numa binding.
-    sudo apt update && \
-    sudo apt install -y numactl && \
-    sudo apt install -y lsb-release && \
-    sudo apt install -y gnupg && \
-    sudo apt install -y curl
-    export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s`
-    echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | sudo tee /etc/apt/sources.list.d/gcsfuse.list
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo tee /usr/share/keyrings/cloud.google.asc
-    sudo apt update -y && sudo apt -y install gcsfuse
-    sudo rm -rf /var/lib/apt/lists/*    
-else
-    # sudo is not available, run the script without sudo
-    # install numactl for numa binding.
-    apt update && \
-    apt install -y numactl && \
-    apt install -y lsb-release && \
-    apt install -y gnupg && \
-    apt install -y curl
-    export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s`
-    echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | tee /etc/apt/sources.list.d/gcsfuse.list
-    curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-    apt update -y && apt -y install gcsfuse
-    rm -rf /var/lib/apt/lists/*    
-fi
+(sudo bash || bash) <<'EOF'
+apt update && \
+apt install -y numactl && \
+apt install -y lsb-release && \
+apt install -y gnupg && \
+apt install -y curl
+export GCSFUSE_REPO=gcsfuse-`lsb_release -c -s`
+echo "deb https://packages.cloud.google.com/apt $GCSFUSE_REPO main" | tee /etc/apt/sources.list.d/gcsfuse.list
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+apt update -y && apt -y install gcsfuse
+rm -rf /var/lib/apt/lists/*
+EOF
 
 # Set environment variables
 for ARGUMENT in "$@"; do


### PR DESCRIPTION
This will solve b/328241961. I tested with the branch
The change: Use "apt-key add -" in both sudo and non-sudo path

Originally, "apt-key add -" is only used in the non sudo path, which is for the docker. The docker image is based on a Debian image that supports apt-key. While the sudo path was for GCE vm, which uses newer ubuntu that is supposed to have apt-key deprecated. But looks apt-key still works in ubuntu 22.04 and won't result in the error in the bug
