### PR TITLE
fix dtype bug in adam_pax

### DIFF
--- a/MaxText/optimizers.py
+++ b/MaxText/optimizers.py
@@ -117,8 +117,13 @@ def adam_pax(
         self.nu = nu
 
     def _update_momentum(update, mu, nu):
-      beta1_decay = bias_corrected_decay(count, beta1)
-      beta2_decay = bias_corrected_decay(count, beta2)
+      # The conversion to the data type of the update ensures that bfloat16 remains
+      # bfloat16 in the optimizer state. This conversion has to be done after
+      # `bias_corrected_dacay` is calculated as calculating `jnp.power(decay, t)` in low
+      # precision can result in it being rounded to 1 and subsequently a
+      # "division by zero" error.
+      beta1_decay = bias_corrected_decay(count, beta1).astype(update)
+      beta2_decay = bias_corrected_decay(count, beta2).astype(update)
       mu = (1.0 - beta1_decay) * update + beta1_decay * mu
       nu = (1.0 - beta2_decay) * (update**2) + beta2_decay * nu
       return _slot_opt_state(mu=mu, nu=nu)


### PR DESCRIPTION
# [[Bug] adam_pax has reuse donated buffer warning](https://github.com/google/maxtext/issues/490)

Reproduced with `weight_dtype=bfloat16`
```shell
python3 MaxText/train.py MaxText/configs/base.yml run_name=run steps=10 weight_dtype=bfloat16 opt_type=adam_pax dataset_type=synthetic enable_checkpointing=false
```

```
/home/lizhiyu/.local/lib/python3.10/site-packages/jax/_src/interpreters/mlir.py:914: 
UserWarning: Some donated buffers were not usable: ShapedArray(bfloat16[512]),
ShapedArray(bfloat16[512,16,7168]), ShapedArray(bfloat16[512,16,7168]), 
ShapedArray(bfloat16[7168,16,512]), ShapedArray(bfloat16[512,16]), ...
```

* root cause
[`bias_corrected_decay`](https://github.com/google/maxtext/blob/47d8e065175a404ce35d43af6a2f378aeb7d1bac/MaxText/optimizers.py#L105) forced optimizer state convert to float32 despite initialization in bfloat16. The data type change of optimizer state broke [buffer donation](https://github.com/google/maxtext/blob/main/MaxText/maxtext_utils.py#L43).
It wasn't an issue for pax gpt3 since all variables are float32.

* solution
Added a new conversion while keeping `bias_corrected_decay` calculated in float32 following [the source code in optax](https://github.com/google-deepmind/optax/blob/72a8614e2dcaf73189d40733a1afabc0cf1521a7/optax/_src/transform.py#L110)

* [x] Verified the warning disappeared after the change.
