### PR TITLE
Adding FP8 support through Native XLA Support

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -98,7 +98,11 @@ jobs:
     - name: Test int8_training
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
-        'python3 MaxText/train.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M)-${RANDOM} base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset quantization=int8 steps=2 enable_checkpointing=false'
+        'python3 MaxText/train.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M)-${RANDOM} base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset quantization=int8 steps=2 enable_checkpointing=false' 
+    - name: Test fp8_training
+      run: |
+        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
+        'python3 MaxText/train.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M)-${RANDOM} base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset quantization=fp8 steps=2 enable_checkpointing=false'
     - name: Test generate_param_only_checkpoint
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -59,7 +59,7 @@ save_config_to_gcs: False
 
 # Activation dtypes.
 dtype: "bfloat16"
-quantization: "" #defaults to no quantization, i.e. bf16. possible alternative setting is 'int8'
+quantization: "" #defaults to no quantization, i.e. bf16. possible alternative setting is 'int8' or use fp8 to run with 8-bit floating-point GeMMs on NVIDIA GPUs.
 quantize_kvcache: False
 
 # Shard the range finding operation for quantization. By default this is set to number of slices.

--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -35,7 +35,7 @@ def main(config):
   tokens, true_length = token_utils.tokenize_and_pad(text, vocab, is_bos=True,
                                                      prefill_lengths=[config.max_prefill_predict_length])
   assert tokens.size <= config.max_prefill_predict_length, "can't take too many tokens"
-
+  assert config.quantization != "fp8", "fp8 on NVIDIA GPUs is not supported in decode.py yet"
   prefill_result = engine.prefill(
       params=params, padded_tokens=tokens, true_length=true_length
   )

--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -282,7 +282,8 @@ class MoeBlock(nn.Module):
             dtype=self.dtype,
             kernel_init=self.kernel_init,
             kernel_axes=self.kernel_axes,
-            name='gate')(inputs)
+            name='gate',
+            quant=self.quant,)(inputs)
 
     weights, selected_experts = lax.top_k(gate_logits, self.num_experts_per_tok)
     weights = jax.nn.softmax(weights.astype(jnp.float32), axis=-1)

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -258,6 +258,7 @@ class Decoder(nn.Module):
               'cache': cache_spec,
               'intermediates': 0,
               'aqt':0,
+              '_overwrite_with_gradient': 0,
           },
           split_rngs={
               'params': True,


### PR DESCRIPTION
@rwitten, following the discussion on https://github.com/google/maxtext/pull/468, I have made changes to call FP8 GeMMs in MaxText through the native XLA support.

I have tested the performance, and looks good on NVIDIA H100.