### PR TITLE
Lower per_device_batch_size for v4 configs

### DIFF
--- a/MaxText/configs/v4/22b.sh
+++ b/MaxText/configs/v4/22b.sh
@@ -47,6 +47,6 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml run_name=$RUN_NAME\
-    ici_fsdp_parallelism=64 steps=10 per_device_batch_size=15 enable_profiler=true remat_policy=full\
+    ici_fsdp_parallelism=64 steps=10 per_device_batch_size=13 enable_profiler=true remat_policy=full\
     base_emb_dim=6144 base_num_kv_heads=24 base_num_query_heads=24 base_mlp_dim=24576 base_num_decoder_layers=48\
     base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH 

--- a/MaxText/configs/v4/52b.sh
+++ b/MaxText/configs/v4/52b.sh
@@ -48,6 +48,6 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml run_name=$RUN_NAME\
     enable_profiler=true enable_checkpointing=false steps=10\
-    ici_fsdp_parallelism=192 ici_tensor_parallelism=1 per_device_batch_size=8 remat_policy=full\
+    ici_fsdp_parallelism=192 ici_tensor_parallelism=1 per_device_batch_size=7 remat_policy=full\
     base_num_decoder_layers=32 base_emb_dim=12288 base_mlp_dim=49152 base_num_query_heads=32 base_num_kv_heads=32 learning_rate=1e-8\
     base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH


### PR DESCRIPTION
Lowering the per_device_batch_size for these v4 configs. Was seeing OOM failures in the nightly XLML AOT tests http://shortn/_ALhnFEdayq.