### PR TITLE
update orbax to latest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 jax>=0.4.23
 jaxlib>=0.4.23
-orbax-checkpoint==0.5.3
+orbax-checkpoint>=0.5.5
 absl-py
 array-record
 aqtp


### PR DESCRIPTION
Orbax's compatibility with jax was fixed. Changing the version to latest to also use `SingleReplicaArrayHandler` directly from pip installation. 