### PR TITLE
Host offload for qkv proj activations

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -86,7 +86,7 @@ logits_via_embedding: False
 normalize_embedding_logits: True  # whether to normlize pre-softmax logits if logits_via_embedding is true
 logits_dot_in_fp32: True  # whether to use fp32 in logits_dense or shared_embedding dot product for stability
 
-# Choose 'remat_policy' between 'minimal', 'save_dot_except_mlpwi', 'save_dot_except_mlp', 'save_qkv_proj', 'minimal_offloaded' and 'full'.
+# Choose 'remat_policy' between 'minimal', 'save_dot_except_mlpwi', 'save_dot_except_mlp', 'save_qkv_proj', 'qkv_proj_offloaded', 'minimal_offloaded' and 'full'.
 # These options offer a trade-off between speed (fastest to slowest) and HBM usage (highest to lowest)
 remat_policy: 'full'
 scan_layers: True

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -233,6 +233,11 @@ class Decoder(nn.Module):
         policy = jax.checkpoint_policies.save_only_these_names(
             'query_proj', 'value_proj', 'key_proj', 'qkv_proj',
         )
+      elif cfg.remat_policy == 'qkv_proj_offloaded':
+        policy = jax.checkpoint_policies.save_and_offload_only_these_names(
+          names_which_can_be_saved=[], 
+          names_which_can_be_offloaded=['query_proj', 'value_proj', 'key_proj'], 
+          offload_src="device", offload_dst="pinned_host")
       elif cfg.remat_policy == 'minimal_offloaded':
         policy = jax.checkpoint_policies.offload_dot_with_no_batch_dims(offload_src="device", offload_dst="pinned_host")
       else:


### PR DESCRIPTION
Tried out llama2 70b host offload with fdsp, we got

v5p-128 MFU 65%  v.s. 63% without offload

with aqt

v5p-128 MFU 87.56% with offload v.s. 85.31% without offload

