### PR TITLE
Add entropy to checkpoints generated by standalone checkpointer.

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -28,6 +28,7 @@ on:
 
 jobs:
   cpu:
+    name: "CPU test"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -94,14 +95,6 @@ jobs:
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
         'python3 MaxText/decode.py MaxText/configs/base.yml run_name=runner_$(date +%Y-%m-%d-%H-%M)-${RANDOM} base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset steps=2 ici_tensor_parallelism=4 attention=dot_product enable_checkpointing=false max_target_length=128 per_device_batch_size=.25'
-    - name: Test standalone_dataloader.py
-      run: |
-        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
-        'python3 MaxText/standalone_dataloader.py MaxText/configs/base.yml run_name=standalone_dataloader_$(date +%Y-%m-%d-%H-%M)-${RANDOM} base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset steps=100 enable_checkpointing=false'
-    - name: Test standalone_checkpointer.py
-      run: |
-        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
-        'python3 MaxText/standalone_checkpointer.py MaxText/configs/base.yml run_name=standalone_checkpointer_$(date +%Y-%m-%d-%H-%M)-${RANDOM} base_output_directory=gs://runner-maxtext-logs dataset_path=gs://maxtext-dataset steps=200 checkpoint_period=50 enable_checkpointing=True async_checkpointing=False'
     - name: Test int8_training
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \

--- a/MaxText/tests/standalone_dl_ckpt_test.py
+++ b/MaxText/tests/standalone_dl_ckpt_test.py
@@ -1,0 +1,59 @@
+"""
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+""" Tests for the standalone_checkpointer.py """
+import unittest
+import pytest
+from standalone_checkpointer import main as sckpt_main
+from standalone_dataloader import main as sdl_main
+from datetime import datetime
+import random
+import string
+
+
+class Standalone_DL_CKPT(unittest.TestCase):
+  """Tests for standalone_checkpointer.py, checkpoint and restore. """
+
+  def _get_random_test_name(self, test_name):
+    now = datetime.now()
+    date_time = now.strftime("_%Y-%m-%d-%H-%M_")
+    random_string = ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(6))
+    random_run_name = test_name + date_time + random_string
+    return random_run_name
+
+  @pytest.mark.tpu
+  def test_standalone_dataloader(self):
+    random_run_name = self._get_random_test_name("standalone_dataloader")
+    sdl_main((None, "configs/base.yml", "run_name="+random_run_name, "base_output_directory=gs://runner-maxtext-logs",
+            "dataset_path=gs://maxtext-dataset", "steps=100", "enable_checkpointing=false",
+            "tokenizer_path=../assets/tokenizer.llama2")) # need to pass relative path to tokenizer
+
+  @pytest.mark.tpu
+  def test_standalone_checkpointer(self):
+    random_run_name = self._get_random_test_name("standalone_checkpointer")
+    # checkpoint at 50
+    sckpt_main((None, "configs/base.yml", f"run_name={random_run_name}", "base_output_directory=gs://runner-maxtext-logs",
+            "dataset_path=gs://maxtext-dataset","base_emb_dim=128", "base_num_query_heads=4", "base_num_kv_heads=4",
+            "base_mlp_dim=128", "base_num_decoder_layers=2", "steps=60", "enable_checkpointing=True",
+            "checkpoint_period=50", "async_checkpointing=False"))
+    # restore at 50 and checkpoint at 100
+    sckpt_main((None, "configs/base.yml", f"run_name={random_run_name}", "base_output_directory=gs://runner-maxtext-logs",
+            "dataset_path=gs://maxtext-dataset","base_emb_dim=128", "base_num_query_heads=4", "base_num_kv_heads=4",
+            "base_mlp_dim=128", "base_num_decoder_layers=2", "steps=110", "enable_checkpointing=True",
+            "checkpoint_period=50", "async_checkpointing=False"))
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
* Add entropy to checkpoints generated by standalone checkpointer on CPUs. This is done by altering the optimizer state of the checkpoints.
* Fix a regression in standalone checkpointer from commit https://github.com/google/maxtext/commit/c9b15991236d84dd8cfba4686a2f725c3adc9b1b . (This commit alters the restored state in setup_initial_state()).
* Update standalone_checkpointer unit test to also check checkpoint restore, moved to PyTest as it is bulky. Moved standalone_dataloader test to Pytest as well.

Thanks to @gobbleturk for helping with the JAX code to add entropy.