### PR TITLE
[airflow] new support to read in run_name from env

### DIFF
--- a/MaxText/configs/v4/22b.sh
+++ b/MaxText/configs/v4/22b.sh
@@ -41,12 +41,20 @@ for ARGUMENT in "$@"; do
     export "$KEY"="$VALUE"
 done
 
+# The setup accommodates two cases:
+# 1) Passing the 'RUN_NAME' variable at runtime
+# 2) Propagating the 'M_RUN_NAME' variable within an Airflow sweeping workflow
+if [ -n "$RUN_NAME" ];
+then
+    export M_RUN_NAME=$RUN_NAME
+fi
+
 # Set up network optimizations
 bash preflight.sh PLATFORM=$PLATFORM
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"
-python3 MaxText/$EXECUTABLE MaxText/configs/base.yml run_name=$RUN_NAME\
+python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     ici_fsdp_parallelism=64 steps=10 per_device_batch_size=13 enable_profiler=true remat_policy=full\
     base_emb_dim=6144 base_num_kv_heads=24 base_num_query_heads=24 base_mlp_dim=24576 base_num_decoder_layers=48\
     base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH 

--- a/MaxText/configs/v4/52b.sh
+++ b/MaxText/configs/v4/52b.sh
@@ -41,12 +41,20 @@ for ARGUMENT in "$@"; do
     export "$KEY"="$VALUE"
 done
 
+# The setup accommodates two cases:
+# 1) Passing the 'RUN_NAME' variable at runtime
+# 2) Propagating the 'M_RUN_NAME' variable within an Airflow sweeping workflow
+if [ -n "$RUN_NAME" ];
+then
+    export M_RUN_NAME=$RUN_NAME
+fi
+
 # Set up network optimizations
 bash preflight.sh PLATFORM=$PLATFORM
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"
-python3 MaxText/$EXECUTABLE MaxText/configs/base.yml run_name=$RUN_NAME\
+python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     enable_profiler=true enable_checkpointing=false steps=10\
     ici_fsdp_parallelism=192 ici_tensor_parallelism=1 per_device_batch_size=7 remat_policy=full\
     base_num_decoder_layers=32 base_emb_dim=12288 base_mlp_dim=49152 base_num_query_heads=32 base_num_kv_heads=32 learning_rate=1e-8\

--- a/MaxText/configs/v5e/128b.sh
+++ b/MaxText/configs/v5e/128b.sh
@@ -27,13 +27,21 @@ for ARGUMENT in "$@"; do
     export "$KEY"="$VALUE"
 done
 
+# The setup accommodates two cases:
+# 1) Passing the 'RUN_NAME' variable at runtime
+# 2) Propagating the 'M_RUN_NAME' variable within an Airflow sweeping workflow
+if [ -n "$RUN_NAME" ];
+then
+    export M_RUN_NAME=$RUN_NAME
+fi
+
 # Set up network
 bash preflight.sh PLATFORM=$PLATFORM
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 
-python3 MaxText/$EXECUTABLE MaxText/configs/base.yml run_name=$RUN_NAME\
+python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=30 per_device_batch_size=1 enable_checkpointing=false\
     enable_profiler=false remat_policy=minimal_offloaded global_parameter_scale=128\
     ici_fsdp_parallelism=16 ici_tensor_parallelism=16\

--- a/MaxText/configs/v5e/16b.sh
+++ b/MaxText/configs/v5e/16b.sh
@@ -27,12 +27,20 @@ for ARGUMENT in "$@"; do
     export "$KEY"="$VALUE"
 done
 
+# The setup accommodates two cases:
+# 1) Passing the 'RUN_NAME' variable at runtime
+# 2) Propagating the 'M_RUN_NAME' variable within an Airflow sweeping workflow
+if [ -n "$RUN_NAME" ];
+then
+    export M_RUN_NAME=$RUN_NAME
+fi
+
 # Set up network optimizations
 bash preflight.sh PLATFORM=$PLATFORM
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
-python3 MaxText/$EXECUTABLE MaxText/configs/base.yml run_name=$RUN_NAME\
+python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=30 per_device_batch_size=6 enable_checkpointing=false\
     enable_profiler=false remat_policy=full global_parameter_scale=16\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\

--- a/MaxText/configs/v5e/32b.sh
+++ b/MaxText/configs/v5e/32b.sh
@@ -27,12 +27,20 @@ for ARGUMENT in "$@"; do
     export "$KEY"="$VALUE"
 done
 
+# The setup accommodates two cases:
+# 1) Passing the 'RUN_NAME' variable at runtime
+# 2) Propagating the 'M_RUN_NAME' variable within an Airflow sweeping workflow
+if [ -n "$RUN_NAME" ];
+then
+    export M_RUN_NAME=$RUN_NAME
+fi
+
 # Set up network optimizations
 bash preflight.sh PLATFORM=$PLATFORM
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
-python3 MaxText/$EXECUTABLE MaxText/configs/base.yml run_name=$RUN_NAME\
+python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=30 per_device_batch_size=4 enable_checkpointing=false\
     enable_profiler=false remat_policy=full global_parameter_scale=32\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\

--- a/MaxText/configs/v5e/64b.sh
+++ b/MaxText/configs/v5e/64b.sh
@@ -27,12 +27,20 @@ for ARGUMENT in "$@"; do
     export "$KEY"="$VALUE"
 done
 
+# The setup accommodates two cases:
+# 1) Passing the 'RUN_NAME' variable at runtime
+# 2) Propagating the 'M_RUN_NAME' variable within an Airflow sweeping workflow
+if [ -n "$RUN_NAME" ];
+then
+    export M_RUN_NAME=$RUN_NAME
+fi
+
 # Set up network optimizations
 bash preflight.sh PLATFORM=$PLATFORM
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
-python3 MaxText/$EXECUTABLE MaxText/configs/base.yml run_name=$RUN_NAME\
+python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=30 per_device_batch_size=2 enable_checkpointing=false\
     enable_profiler=false remat_policy=full global_parameter_scale=64\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\

--- a/MaxText/configs/v5p/1024b.sh
+++ b/MaxText/configs/v5p/1024b.sh
@@ -27,12 +27,20 @@ for ARGUMENT in "$@"; do
     export "$KEY"="$VALUE"
 done
 
+# The setup accommodates two cases:
+# 1) Passing the 'RUN_NAME' variable at runtime
+# 2) Propagating the 'M_RUN_NAME' variable within an Airflow sweeping workflow
+if [ -n "$RUN_NAME" ];
+then
+    export M_RUN_NAME=$RUN_NAME
+fi
+
 # Set up network optimizations
 bash preflight.sh PLATFORM=$PLATFORM
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
-python3 MaxText/$EXECUTABLE MaxText/configs/base.yml run_name=$RUN_NAME\
+python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=20 per_device_batch_size=2 enable_checkpointing=false\
     enable_profiler=false remat_policy=full global_parameter_scale=1024\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=16\

--- a/MaxText/configs/v5p/128b.sh
+++ b/MaxText/configs/v5p/128b.sh
@@ -27,12 +27,20 @@ for ARGUMENT in "$@"; do
     export "$KEY"="$VALUE"
 done
 
+# The setup accommodates two cases:
+# 1) Passing the 'RUN_NAME' variable at runtime
+# 2) Propagating the 'M_RUN_NAME' variable within an Airflow sweeping workflow
+if [ -n "$RUN_NAME" ];
+then
+    export M_RUN_NAME=$RUN_NAME
+fi
+
 # Set up network optimizations
 bash preflight.sh PLATFORM=$PLATFORM
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
-python3 MaxText/$EXECUTABLE MaxText/configs/base.yml run_name=$RUN_NAME\
+python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=30 per_device_batch_size=1 enable_checkpointing=false\
     enable_profiler=false remat_policy=minimal global_parameter_scale=128\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=8\

--- a/MaxText/configs/v5p/256b.sh
+++ b/MaxText/configs/v5p/256b.sh
@@ -27,12 +27,20 @@ for ARGUMENT in "$@"; do
     export "$KEY"="$VALUE"
 done
 
+# The setup accommodates two cases:
+# 1) Passing the 'RUN_NAME' variable at runtime
+# 2) Propagating the 'M_RUN_NAME' variable within an Airflow sweeping workflow
+if [ -n "$RUN_NAME" ];
+then
+    export M_RUN_NAME=$RUN_NAME
+fi
+
 # Set up network optimizations
 bash preflight.sh PLATFORM=$PLATFORM
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
-python3 MaxText/$EXECUTABLE MaxText/configs/base.yml run_name=$RUN_NAME\
+python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=20 per_device_batch_size=1 enable_checkpointing=false\
     enable_profiler=false remat_policy=minimal global_parameter_scale=256\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=8\

--- a/MaxText/configs/v5p/32b.sh
+++ b/MaxText/configs/v5p/32b.sh
@@ -27,12 +27,20 @@ for ARGUMENT in "$@"; do
     export "$KEY"="$VALUE"
 done
 
+# The setup accommodates two cases:
+# 1) Passing the 'RUN_NAME' variable at runtime
+# 2) Propagating the 'M_RUN_NAME' variable within an Airflow sweeping workflow
+if [ -n "$RUN_NAME" ];
+then
+    export M_RUN_NAME=$RUN_NAME
+fi
+
 # Set up network optimizations
 bash preflight.sh PLATFORM=$PLATFORM
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
-python3 MaxText/$EXECUTABLE MaxText/configs/base.yml run_name=$RUN_NAME\
+python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=30 per_device_batch_size=6 enable_checkpointing=false\
     enable_profiler=false remat_policy=minimal global_parameter_scale=32\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=4\

--- a/MaxText/configs/v5p/512b.sh
+++ b/MaxText/configs/v5p/512b.sh
@@ -27,12 +27,20 @@ for ARGUMENT in "$@"; do
     export "$KEY"="$VALUE"
 done
 
+# The setup accommodates two cases:
+# 1) Passing the 'RUN_NAME' variable at runtime
+# 2) Propagating the 'M_RUN_NAME' variable within an Airflow sweeping workflow
+if [ -n "$RUN_NAME" ];
+then
+    export M_RUN_NAME=$RUN_NAME
+fi
+
 # Set up network optimizations
 bash preflight.sh PLATFORM=$PLATFORM
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
-python3 MaxText/$EXECUTABLE MaxText/configs/base.yml run_name=$RUN_NAME\
+python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=20 per_device_batch_size=2 enable_checkpointing=false\
     enable_profiler=false remat_policy=full global_parameter_scale=512\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=8\

--- a/MaxText/configs/v5p/64b.sh
+++ b/MaxText/configs/v5p/64b.sh
@@ -27,12 +27,20 @@ for ARGUMENT in "$@"; do
     export "$KEY"="$VALUE"
 done
 
+# The setup accommodates two cases:
+# 1) Passing the 'RUN_NAME' variable at runtime
+# 2) Propagating the 'M_RUN_NAME' variable within an Airflow sweeping workflow
+if [ -n "$RUN_NAME" ];
+then
+    export M_RUN_NAME=$RUN_NAME
+fi
+
 # Set up network optimizations
 bash preflight.sh PLATFORM=$PLATFORM
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
-python3 MaxText/$EXECUTABLE MaxText/configs/base.yml run_name=$RUN_NAME\
+python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=30 per_device_batch_size=3 enable_checkpointing=false\
     enable_profiler=false remat_policy=minimal global_parameter_scale=64\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=4\


### PR DESCRIPTION
Airflow XLML sweeping tests need to 
* create `RUN_NAME` (mainly for later metrics tracking)
* propagate environment `M_RUN_NAME` variable to the run script

We update the scripts to allow 
* Passing the 'RUN_NAME' variable at runtime
* Propagating the 'M_RUN_NAME' variable within an Airflow sweeping workflow

It follows the same reason and see [the previous PR](https://github.com/google/maxtext/pull/512) for more details.

- [x] tested in [a subset sweeping](https://569ece7f7b52483e8c6c58cf42f13d68-dot-us-central1.composer.googleusercontent.com/dags/maxtext_aqtp_version_sweep_gke_example_dag_3/grid)