### PR TITLE
Consistent Usage of Params Within MaxText

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -110,6 +110,10 @@ jobs:
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
         'bash end_to_end/test_generate_param_only_checkpoint.sh -r runner_$(date +%Y-%m-%d-%H-%M)-${RANDOM} -o gs://runner-maxtext-logs -d gs://maxtext-dataset -i 4'
+    - name: Test generate_param_only_checkpoint with int8 quantization
+      run: |
+        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
+        'bash end_to_end/test_generate_param_only_checkpoint.sh -r runner_$(date +%Y-%m-%d-%H-%M)-${RANDOM} -o gs://runner-maxtext-logs -d gs://maxtext-dataset -i 4 -q int8'
     - name: Test grain checkpoint determinism
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "python.testing.pytestArgs": [],
+    "python.testing.cwd": "${workspaceFolder}/MaxText",
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/MaxText/checkpointing.py
+++ b/MaxText/checkpointing.py
@@ -178,8 +178,10 @@ def load_state_if_possible(checkpoint_manager: CheckpointManager,
     p = epath.Path(load_parameters_from_path)
     ckptr = orbax.checkpoint.PyTreeCheckpointer()
     restore_args = orbax.checkpoint.checkpoint_utils.construct_restore_args(abstract_unboxed_pre_state.params)
+    # Orbax syntax -> We are telling Orbax that there is a pytree in this checkpoint named 'params'
+    # and how to handle it. We would need to handle any future collections (like a batch_stats) similarly
     restored = ckptr.restore(p, item = {'params': abstract_unboxed_pre_state.params}, transforms={},
-                             restore_args = {'params': restore_args})
+                              restore_args = {'params': restore_args})
 
     return None, restored['params']
 

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -349,13 +349,12 @@ def init_initial_state(model, tx, config, is_training, key):
                           jnp.ones(input_shape, dtype=jnp.int32),
                           jnp.ones(input_shape, dtype=jnp.int32))
   if is_training:
-    return init_training_state(model.apply, model_vars['params'], tx)
-  return init_decode_state(model.apply, model_vars['params'])
+    return init_training_state(model.apply, model_vars, tx)
+  return init_decode_state(model.apply, model_vars)
 
 def load_decode_model_vars(model, config, rng, mesh):
   state, _ = setup_decode_state(model, config, rng, mesh, None)
-  model_vars = {'params': state.params}
-  return model_vars
+  return state.params
 
 def setup_decode_state(model, config, rng, mesh, checkpoint_manager):
   is_training = False

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -209,7 +209,7 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
     for k, v in data.items():
       data[k] = v[:config.global_batch_size_to_train_on,:]
 
-  logits, intermediate_outputs = model.apply({'params': params},
+  logits, intermediate_outputs = model.apply(params,
                        data['inputs'],
                        data['inputs_position'],
                        decoder_segment_ids=data['inputs_segmentation'],

--- a/end_to_end/test_generate_param_only_checkpoint.sh
+++ b/end_to_end/test_generate_param_only_checkpoint.sh
@@ -12,6 +12,7 @@ helpFunction()
   echo -e "\t-o output_path: gs://test-maxtext-output"
   echo -e "\t-i ici_tensor_parallelism: 8"
   echo -e "\t-a attention: flash"
+  echo -e "\t-q quantization: int8"
   exit 1 # Exit script after printing help
 }
 
@@ -22,8 +23,9 @@ dataset_path=gs://test-maxtext-dataset
 base_output_directory=gs://test-maxtext-output
 ici_tensor_parallelism=8
 attention=flash
+quantization=""
 
-while getopts "nr:d:o:t:i:a:" opt
+while getopts "nr:d:o:t:i:a:q:" opt
 do
   case "$opt" in
       n ) dry_run=true ;;
@@ -32,6 +34,7 @@ do
       o ) base_output_directory="$OPTARG";;
       i ) ici_tensor_parallelism="$OPTARG" ;;
       a ) attention="$OPTARG" ;;
+      q ) quantization="int8" ;;
       ? ) helpFunction ;; # Print helpFunction in case parameter is non-existent
   esac
 done
@@ -39,7 +42,7 @@ done
 echo
 echo "Running: ./$0 dataset_path=${dataset_path} base_output_directory=${base_output_directory}"
 echo "          dry_run=${dry_run} run_id=${run_id}  "
-echo "          ici_tensor_parallelism=${ici_tensor_parallelism} attention=${attention}"
+echo "          ici_tensor_parallelism=${ici_tensor_parallelism} attention=${attention} quantization=${quantization}"
 echo
 
 if "$dry_run"; then
@@ -60,6 +63,7 @@ run_name=${training_ckpt_run_id} \
 base_output_directory=${base_output_directory} \
 dataset_path=${dataset_path} attention=${attention} \
 steps=5 checkpoint_period=3 async_checkpointing=false \
+quantization=${quantization} \
 ${model_params} \
 
 
@@ -83,6 +87,7 @@ run_name=${decode_ckpt_run_id} attention=${attention} \
 base_output_directory=${base_output_directory} \
 dataset_path=${dataset_path} async_checkpointing=false \
 load_full_state_path=${base_output_directory}/${training_ckpt_run_id}/checkpoints/3/items \
+quantization=${quantization} \
 ${model_params} \
 
 
@@ -106,6 +111,7 @@ dataset_path=${dataset_path} \
 load_parameters_path=${base_output_directory}/${decode_ckpt_run_id}/checkpoints/0/items \
 attention=dot_product ici_tensor_parallelism=${ici_tensor_parallelism} steps=50 \
 metrics_file=/tmp/${run_id}_metrics.txt async_checkpointing=false max_target_length=128 per_device_batch_size=1 \
+quantization=${quantization} \
 ${model_params} \
 
 if [ $? -eq 0 ]


### PR DESCRIPTION
https://github.com/google/maxtext/pull/498 Showed that we have inconsistent use of params vs {'params': params} within MaxText, which causes problems when we have changes that require multiple collections of variables (like https://github.com/google/flax/blob/main/flax/linen/fp8_ops.py).

These changes streamline this as much as possible to use params directly, except for places that break out of standard Jax/Flax and have more complexity.