### PR TITLE
Make Usage of Params Consistent v2

### DIFF
--- a/.github/workflows/UnitTests.yml
+++ b/.github/workflows/UnitTests.yml
@@ -103,6 +103,10 @@ jobs:
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
         'bash end_to_end/test_generate_param_only_checkpoint.sh -r runner_$(date +%Y-%m-%d-%H-%M)-${RANDOM} -o gs://runner-maxtext-logs -d gs://maxtext-dataset -i 4'
+    - name: Test generate_param_only_checkpoint with int8 quantization
+      run: |
+        docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \
+        'bash end_to_end/test_generate_param_only_checkpoint.sh -r runner_$(date +%Y-%m-%d-%H-%M)-${RANDOM} -o gs://runner-maxtext-logs -d gs://maxtext-dataset -i 4 -q int8'
     - name: Test grain checkpoint determinism
       run: |
         docker run -v /home/runner/actions-runner/_work/maxtext/maxtext:/app --rm --privileged maxtext_base_image bash -c \

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "python.testing.pytestArgs": [],
+    "python.testing.cwd": "${workspaceFolder}/MaxText",
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/MaxText/checkpointing.py
+++ b/MaxText/checkpointing.py
@@ -177,10 +177,13 @@ def load_state_if_possible(checkpoint_manager: CheckpointManager,
     max_logging.log(f"restoring params from {load_parameters_from_path=}")
     p = epath.Path(load_parameters_from_path)
     ckptr = orbax.checkpoint.PyTreeCheckpointer()
+    # This is a memory optimization. We don't want to restore the entire checkpoint - only the params.
+    # Rather than pass the entire abstract state, which could unnecessarily restore opt_state and such and waste
+    # memory, we instead specify here that we are just restoring the params field of the checkpoint
+    # (which itself may be a dictionary containing a key named 'params').
     restore_args = orbax.checkpoint.checkpoint_utils.construct_restore_args(abstract_unboxed_pre_state.params)
     restored = ckptr.restore(p, item = {'params': abstract_unboxed_pre_state.params}, transforms={},
-                             restore_args = {'params': restore_args})
-
+                                restore_args = {'params': restore_args})
     return None, restored['params']
 
   elif load_full_state_from_path != "":

--- a/MaxText/convert_gemma_chkpt.py
+++ b/MaxText/convert_gemma_chkpt.py
@@ -181,7 +181,7 @@ def main(raw_args=None) -> None:
   state_new = train_state.TrainState(
     step=0,
     apply_fn=None,
-    params=jax_weights,
+    params={'params': jax_weights},
     tx=None, # type: ignore
     opt_state={}
   )

--- a/MaxText/convert_gpt3_ckpt_from_paxml.py
+++ b/MaxText/convert_gpt3_ckpt_from_paxml.py
@@ -148,12 +148,12 @@ def convert(paxml_ckpt_path, maxtext_model_name, base_output_directory, run_name
 
   for keystr_maxtext, (keystr_pax, transform_fn) in keystr_map.items():
     # model variable
-    state_map[f".params{keystr_maxtext}"] = (f"mdl_vars{keystr_pax}", transform_fn)
+    state_map[f".params['params']{keystr_maxtext}"] = (f"mdl_vars{keystr_pax}", transform_fn)
     prefix_pax_opt_state = get_layer_prefix(keystr_pax)
     # first momentum in optimizer state
-    state_map[f".opt_state.mu{keystr_maxtext}"] = (f"opt_states_0.{prefix_pax_opt_state}.m{keystr_pax}", transform_fn)
+    state_map[f".opt_state.mu['params']{keystr_maxtext}"] = (f"opt_states_0.{prefix_pax_opt_state}.m{keystr_pax}", transform_fn)
     # second momentum in optimizer state
-    state_map[f".opt_state.nu{keystr_maxtext}"] = (f"opt_states_0.{prefix_pax_opt_state}.v{keystr_pax}", transform_fn)
+    state_map[f".opt_state.nu['params']{keystr_maxtext}"] = (f"opt_states_0.{prefix_pax_opt_state}.v{keystr_pax}", transform_fn)
 
   def verify_fn(key_path, _):
     keystr = jax.tree_util.keystr(key_path)

--- a/MaxText/generate_param_only_checkpoint.py
+++ b/MaxText/generate_param_only_checkpoint.py
@@ -47,8 +47,8 @@ def _possibly_unroll_params(config, training_state, training_state_annotations, 
   if not config.scan_layers or not config.force_unroll:
     return
 
-  training_state_layers = training_state.params['decoder']['layers']
-  training_state_annotations_layers = training_state_annotations.params['decoder']['layers']
+  training_state_layers = training_state.params['params']['decoder']['layers']
+  training_state_annotations_layers = training_state_annotations.params['params']['decoder']['layers']
 
   def new_pspec(x):
     return jax.sharding.PartitionSpec(*x[0:config.param_scan_axis] + x[config.param_scan_axis+1:])
@@ -62,11 +62,11 @@ def _possibly_unroll_params(config, training_state, training_state_annotations, 
 
     new_layer = jax.jit(slice_ith, out_shardings = new_per_layer_state_sharding)(training_state_layers)
 
-    training_state.params['decoder'][f'layers_{i}'] = new_layer
-    training_state_annotations.params['decoder'][f'layers_{i}'] = new_per_layer_state_annotation
+    training_state.params['params']['decoder'][f'layers_{i}'] = new_layer
+    training_state_annotations.params['params']['decoder'][f'layers_{i}'] = new_per_layer_state_annotation
 
-  del training_state.params['decoder']['layers']
-  del training_state_annotations.params['decoder']['layers']
+  del training_state.params['params']['decoder']['layers']
+  del training_state_annotations.params['params']['decoder']['layers']
 
   jax.tree_map(lambda x : x.delete(), training_state_layers)
 

--- a/MaxText/llama_or_mistral_ckpt.py
+++ b/MaxText/llama_or_mistral_ckpt.py
@@ -383,7 +383,7 @@ def convert(base_model_path, maxtext_model_path, model_size):
   state_new = train_state.TrainState(
       step=0,
       apply_fn=None,
-      params=jax_weights,
+      params={'params': jax_weights},
       tx=None,  # type: ignore
       opt_state={}
   )

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -347,13 +347,12 @@ def init_initial_state(model, tx, config, is_training, key):
                           jnp.ones(input_shape, dtype=jnp.int32),
                           jnp.ones(input_shape, dtype=jnp.int32))
   if is_training:
-    return init_training_state(model.apply, model_vars['params'], tx)
-  return init_decode_state(model.apply, model_vars['params'])
+    return init_training_state(model.apply, model_vars, tx)
+  return init_decode_state(model.apply, model_vars)
 
 def load_decode_model_vars(model, config, rng, mesh):
   state, _ = setup_decode_state(model, config, rng, mesh, None)
-  model_vars = {'params': state.params}
-  return model_vars
+  return state.params
 
 def setup_decode_state(model, config, rng, mesh, checkpoint_manager):
   is_training = False

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -211,7 +211,7 @@ def loss_fn(model, config, data, dropout_rng, params, is_train=True):
     for k, v in data.items():
       data[k] = v[:config.global_batch_size_to_train_on,:]
 
-  logits, intermediate_outputs = model.apply({'params': params},
+  logits, intermediate_outputs = model.apply(params,
                        data['inputs'],
                        data['inputs_position'],
                        decoder_segment_ids=data['inputs_segmentation'],

--- a/end_to_end/test_generate_param_only_checkpoint.sh
+++ b/end_to_end/test_generate_param_only_checkpoint.sh
@@ -12,6 +12,7 @@ helpFunction()
   echo -e "\t-o output_path: gs://test-maxtext-output"
   echo -e "\t-i ici_tensor_parallelism: 8"
   echo -e "\t-a attention: flash"
+  echo -e "\t-q quantization: int8"
   exit 1 # Exit script after printing help
 }
 
@@ -22,8 +23,9 @@ dataset_path=gs://test-maxtext-dataset
 base_output_directory=gs://test-maxtext-output
 ici_tensor_parallelism=8
 attention=flash
+quantization=""
 
-while getopts "nr:d:o:t:i:a:" opt
+while getopts "nr:d:o:t:i:a:q:" opt
 do
   case "$opt" in
       n ) dry_run=true ;;
@@ -32,6 +34,7 @@ do
       o ) base_output_directory="$OPTARG";;
       i ) ici_tensor_parallelism="$OPTARG" ;;
       a ) attention="$OPTARG" ;;
+      q ) quantization="int8" ;;
       ? ) helpFunction ;; # Print helpFunction in case parameter is non-existent
   esac
 done
@@ -39,7 +42,7 @@ done
 echo
 echo "Running: ./$0 dataset_path=${dataset_path} base_output_directory=${base_output_directory}"
 echo "          dry_run=${dry_run} run_id=${run_id}  "
-echo "          ici_tensor_parallelism=${ici_tensor_parallelism} attention=${attention}"
+echo "          ici_tensor_parallelism=${ici_tensor_parallelism} attention=${attention} quantization=${quantization}"
 echo
 
 if "$dry_run"; then
@@ -60,6 +63,7 @@ run_name=${training_ckpt_run_id} \
 base_output_directory=${base_output_directory} \
 dataset_path=${dataset_path} attention=${attention} \
 steps=5 checkpoint_period=3 async_checkpointing=false \
+quantization=${quantization} \
 ${model_params} \
 
 
@@ -83,6 +87,7 @@ run_name=${decode_ckpt_run_id} attention=${attention} \
 base_output_directory=${base_output_directory} \
 dataset_path=${dataset_path} async_checkpointing=false \
 load_full_state_path=${base_output_directory}/${training_ckpt_run_id}/checkpoints/3/items \
+quantization=${quantization} \
 ${model_params} \
 
 
@@ -106,6 +111,7 @@ dataset_path=${dataset_path} \
 load_parameters_path=${base_output_directory}/${decode_ckpt_run_id}/checkpoints/0/items \
 attention=dot_product ici_tensor_parallelism=${ici_tensor_parallelism} steps=50 \
 metrics_file=/tmp/${run_id}_metrics.txt async_checkpointing=false max_target_length=128 per_device_batch_size=1 \
+quantization=${quantization} \
 ${model_params} \
 
 if [ $? -eq 0 ]


### PR DESCRIPTION
https://github.com/google/maxtext/pull/498 Showed that we have inconsistent use of params vs {'params': params} within MaxText, which causes problems when we have changes that require multiple collections of variables (like https://github.com/google/flax/blob/main/flax/linen/fp8_ops.py).

These changes streamline this as much as possible to use params directly. 

**Changes from Last Time:** 
The last version of this PR caused issues because it didn't update the checkpoint conversion scripts. Those have now been updated to reflected the updated checkpoint structure (which is basically just a 'params' wrapping the outside of the dict). 