### PR TITLE
Change docker upload schedule

### DIFF
--- a/.github/workflows/UploadDockerImages.yml
+++ b/.github/workflows/UploadDockerImages.yml
@@ -19,8 +19,8 @@ name: Build Images
 
 on:
   schedule:
-    # Run the job daily at 7PM PST (3AM UTC)
-    - cron:  '0 3 * * *'
+    # Run the job daily at 12AM UTC
+    - cron:  '0 0 * * *'
 
 jobs:
   tpu:


### PR DESCRIPTION
Airflow looks for MaxText docker image based on datetime and cannot find it since we upload them at 3:00 AM UTC. 
This effects users testing their new Airflow tests locally. 