### PR TITLE
define default mode quantize_kvcache parameter

### DIFF
--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -90,7 +90,7 @@ class DecoderLayer(nn.Module):
       dropout_rate=cfg.dropout_rate,
       name='self_attention',
       quant=self.quant,
-      quantize_kvcache=self.quantize_kvcache)
+      quantize_kvcache=cfg.quantize_kvcache)
 
 
     attention_lnx = attention_layer(


### PR DESCRIPTION
The default decoder layer does not have the `quantize_kvcache` parameter defined. It is causing the default decoder layer run to fail. This PR changes the `self.quantize_kvcache` to `cfg.quantize_kvcache`.