### PR TITLE
Match the dtype of sin and cos with inputs in RotaryEmbedding

### DIFF
--- a/MaxText/layers/embeddings.py
+++ b/MaxText/layers/embeddings.py
@@ -164,8 +164,8 @@ class RotaryEmbedding(nn.Module):
     )
     position = position[:, :, jnp.newaxis, jnp.newaxis]
     sinusoid_inp = position / timescale
-    sin = jnp.sin(sinusoid_inp)
-    cos = jnp.cos(sinusoid_inp)
+    sin = jnp.sin(sinusoid_inp).astype(inputs.dtype)
+    cos = jnp.cos(sinusoid_inp).astype(inputs.dtype)
     first_half, second_half = jnp.split(inputs, 2, axis=-1)
     first_part = first_half * cos - second_half * sin
     second_part = second_half * cos + first_half * sin


### PR DESCRIPTION
`jnp.sin` and `jnp.cos` appear to default to fp32, but in cases where all bf16 is being used, this causes dtype incompatibility in the attention mechanism. By setting them to match the input, the dtype of the output of RotaryEmbedding matches that of input, per user intuition and expectation.