### PR TITLE
Call max_utils.get_project() only when Vertex Tensorboard is enabled

### DIFF
--- a/MaxText/tests/train_gpu_smoke_test.py
+++ b/MaxText/tests/train_gpu_smoke_test.py
@@ -25,7 +25,6 @@ class Train(unittest.TestCase):
 
   def test_tiny_config(self):
     test_tmpdir = os.environ.get("TEST_TMPDIR")
-    os.environ["TENSORBOARD_PROJECT"] = "test-project"
     train_main([
         None,
         "third_party/py/maxtext/configs/gpu_smoke_test.yml",

--- a/MaxText/tests/train_int8_smoke_test.py
+++ b/MaxText/tests/train_int8_smoke_test.py
@@ -25,7 +25,6 @@ class Train(unittest.TestCase):
 
   def test_tiny_config(self):
     test_tmpdir = os.environ.get("TEST_TMPDIR")
-    os.environ["TENSORBOARD_PROJECT"] = "test-project"
     train_main([None, "third_party/py/maxtext/configs/base.yml",
       f"base_output_directory=gs://runner-maxtext-logs", "run_name=runner_test",
       r"dataset_path=gs://maxtext-dataset",

--- a/MaxText/tests/train_smoke_test.py
+++ b/MaxText/tests/train_smoke_test.py
@@ -25,7 +25,6 @@ class Train(unittest.TestCase):
 
   def test_tiny_config(self):
     test_tmpdir = os.environ.get("TEST_TMPDIR")
-    os.environ["TENSORBOARD_PROJECT"] = "test-project"
     train_main([None, "third_party/py/maxtext/configs/base.yml",
       f"base_output_directory=gs://runner-maxtext-logs", "run_name=runner_test",
       r"dataset_path=gs://maxtext-dataset",

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -508,7 +508,8 @@ def main(argv: Sequence[str]) -> None:
   validate_train_config(config)
   os.environ["TFDS_DATA_DIR"] = config.dataset_path
   vertex_tensorboard_manager = VertexTensorboardManager()
-  vertex_tensorboard_manager.configure_vertex_tensorboard(config)
+  if config.use_vertex_tensorboard or os.environ.get("UPLOAD_DATA_TO_TENSORBOARD"):
+    vertex_tensorboard_manager.configure_vertex_tensorboard(config)
 
   debug_config = debug_configuration.DebugConfig(
     stack_trace_config = stack_trace_configuration.StackTraceConfig(


### PR DESCRIPTION
`configure_vertex_tensorboard()` method internally calls `max_utils.get_project()` to get the project name set using `gcloud config set project` command. This would fail if gcloud command is not supported. This PR calls `configure_vertex_tensorboard()` method only for the cases when uploading data to Vertex AI Tensorboard is enabled by the user.