### PR TITLE
Fix Microbenchmark Profiling Memory Issues

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -264,3 +264,8 @@ vertex_tensorboard_region: ""
 
 # If set to True, MaxText will perform extra checks using jax.checkify. Note that this will effect performance. 
 max_checkify: False
+
+# Inference
+inference_microbenchmark_prefill_lengths: "64,128,256,512,1024"
+inference_microbenchmark_stages: "prefill,generate"
+inference_microbenchmark_loop_iters: 10

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -652,3 +652,30 @@ def get_project():
     max_logging.log("You must specify config.vertex_tensorboard_project or set 'gcloud config set project <project>'")
     return None
   return project_outputs[-1]
+
+
+def delete_pytree(p):
+  def delete_leaf(leaf):
+    if isinstance(leaf, jax.Array):
+      leaf.delete()
+    del leaf
+
+  jax.tree_map(delete_leaf, p)
+
+
+def summarize_pytree_data(params, name="Params", raw=False):
+  """Generate basic metrics of a given Pytree."""
+  num_params, total_param_size, avg_param_size = summarize_size_from_pytree(params)
+  if not raw:
+    num_params_in_billions = num_params / 1e9
+    total_param_size_in_gb = total_param_size / 1e9
+    print(f"{name} stats: \n"
+          f"\tTotal number of params: {num_params_in_billions:.3f} billion \n"	
+          f"\tTotal memory usage: {total_param_size_in_gb:.3f} GB \n"	
+          f"\tAvg size: {avg_param_size:.3f} bytes\n")	
+  else:
+    print(f"{name} stats: \n"
+            f"\tTotal number of params: {num_params:.3f} \n"
+            f"\tTotal memory usage: {total_param_size:.3f} bytes \n"
+            f"\tAvg size: {avg_param_size:.3f} bytes\n")
+  return num_params, total_param_size, avg_param_size


### PR DESCRIPTION
Below are changes in this PR

  - allow microbenchmark with prefill lengths
  - allow microbenchmark with loop iters
  - allow benchmark prefill / generate stage only
  - delete prefill_results to that limited the batch size
  - added / move pytree util funcs
