### PR TITLE
Update instructions for installing snap.

### DIFF
--- a/getting_started/Run_MaxText_via_xpk.md
+++ b/getting_started/Run_MaxText_via_xpk.md
@@ -28,6 +28,8 @@ This document focuses on steps required to setup XPK on TPU VM and assumes you h
 
 * gcloud is installed on TPUVMs using the snap distribution package. Install kubectl using snap
 ```shell
+sudo apt get update
+sudo apt install snapd
 sudo snap install kubectl --classic
 ```
 * Install `gke-gcloud-auth-plugin`


### PR DESCRIPTION
To mitigate "snap not found" error with `sudo snap install kubectl --classic`.