### PR TITLE
change norm sharding

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -125,6 +125,7 @@ logical_axis_rules: [
                       ['vocab', ['tensor', 'autoregressive']],
                       ['embed', ['fsdp', 'fsdp_transpose', 'sequence']],
                       ['embed', ['fsdp', 'sequence']],
+                      ['norm', 'tensor'],
                       ['heads', ['tensor', 'autoregressive']],
                       ['kv', []],
                       ['cache_batch', []],

--- a/MaxText/generate_param_only_checkpoint.py
+++ b/MaxText/generate_param_only_checkpoint.py
@@ -55,7 +55,8 @@ def _possibly_unroll_params(config, training_state, training_state_annotations, 
     return jax.sharding.PartitionSpec(*x[0 : config.param_scan_axis] + x[config.param_scan_axis + 1 :])
 
   new_per_layer_state_annotation = jax.tree_util.tree_map(new_pspec, training_state_annotations_layers)
-  new_per_layer_state_sharding = jax.tree_util.tree_map(lambda x: jax.sharding.NamedSharding(mesh, x), new_per_layer_state_annotation)
+  new_per_layer_state_sharding = jax.tree_util.tree_map(
+    lambda x: jax.sharding.NamedSharding(mesh, x), new_per_layer_state_annotation)
 
   for i in range(config.num_decoder_layers):
 
@@ -90,7 +91,8 @@ def _read_train_checkpoint(config, checkpoint_manager, mesh):
 def _save_decode_checkpoint(config, state, checkpoint_manager):
   """Generate checkpoint for decode from the training_state."""
   with jax.spmd_mode("allow_all"):
-    decode_state = max_utils.init_decode_state(None, jax.tree_util.tree_map(lambda x: x.astype(jax.numpy.bfloat16), state.params))
+    decode_state = max_utils.init_decode_state(
+      None, jax.tree_util.tree_map(lambda x: x.astype(jax.numpy.bfloat16), state.params))
   if checkpoint_manager is not None:
     if save_checkpoint(checkpoint_manager, 0, decode_state):
       max_logging.log(f"saved an decode checkpoint at {config.checkpoint_dir}")

--- a/MaxText/layers/gemma.py
+++ b/MaxText/layers/gemma.py
@@ -71,7 +71,7 @@ class GemmaDecoderLayer(nn.Module):
     inputs = nn.with_logical_constraint(inputs, ("activation_batch", "activation_length", "activation_embed"))
 
     # inputs: embedded inputs to the decoder with shape [batch, length, emb_dim]
-    lnx = RMSNorm(dtype=cfg.dtype, weight_dtype=cfg.weight_dtype, name="pre_self_attention_norm", kernel_axes=("embed",))(
+    lnx = RMSNorm(dtype=cfg.dtype, weight_dtype=cfg.weight_dtype, name="pre_self_attention_norm", kernel_axes=("norm",))(
         inputs
     )
 
@@ -108,7 +108,7 @@ class GemmaDecoderLayer(nn.Module):
     attention_lnx = nn.with_logical_constraint(attention_lnx, ("activation_batch", "activation_length", "activation_embed"))
     attention_lnx += inputs
     residual = attention_lnx
-    attn_output = RMSNorm(dtype=cfg.dtype, weight_dtype=cfg.weight_dtype, name="pre_ffw_norm", kernel_axes=("embed",))(
+    attn_output = RMSNorm(dtype=cfg.dtype, weight_dtype=cfg.weight_dtype, name="pre_ffw_norm", kernel_axes=("norm",))(
         attention_lnx
     )
 

--- a/MaxText/layers/gpt3.py
+++ b/MaxText/layers/gpt3.py
@@ -278,7 +278,7 @@ class Gpt3DecoderLayer(nn.Module):
     lnx_layer_norm = Gpt3LayerNorm(
         dtype=cfg.dtype,
         name="pre_self_attention_norm",
-        kernel_axes=("embed",),
+        kernel_axes=("norm",),
         epsilon=cfg.normalization_layer_epsilon,
         reductions_in_fp32=False,
         use_bias=True,

--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -197,7 +197,7 @@ class MlpBlock(nn.Module):
           name="mlp_layer_norm",
           dtype=cfg.dtype,
           weight_dtype=cfg.weight_dtype,
-          kernel_axes=("embed",),
+          kernel_axes=("norm",),
           epsilon=cfg.normalization_layer_epsilon,
       )(inputs)
 

--- a/MaxText/layers/llama2.py
+++ b/MaxText/layers/llama2.py
@@ -73,7 +73,7 @@ class LlamaDecoderLayer(nn.Module):
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
         name="pre_self_attention_layer_norm",
-        kernel_axes=("embed",),
+        kernel_axes=("norm",),
         epsilon=cfg.normalization_layer_epsilon,
     )
     lnx = lnx_rms(inputs)
@@ -115,7 +115,7 @@ class LlamaDecoderLayer(nn.Module):
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
         name="post_self_attention_layer_norm",
-        kernel_axes=("embed",),
+        kernel_axes=("norm",),
         epsilon=cfg.normalization_layer_epsilon,
     )(intermediate_inputs)
     hidden_states = nn.with_logical_constraint(hidden_states, ("activation_batch", "activation_length", "activation_embed"))

--- a/MaxText/layers/mistral.py
+++ b/MaxText/layers/mistral.py
@@ -74,7 +74,7 @@ class MistralDecoderLayer(nn.Module):
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
         name="pre_self_attention_layer_norm",
-        kernel_axes=("embed",),
+        kernel_axes=("norm",),
         epsilon=cfg.normalization_layer_epsilon,
     )
     lnx = lnx_rms(inputs)
@@ -116,7 +116,7 @@ class MistralDecoderLayer(nn.Module):
         dtype=cfg.dtype,
         weight_dtype=cfg.weight_dtype,
         name="post_self_attention_layer_norm",
-        kernel_axes=("embed",),
+        kernel_axes=("norm",),
         epsilon=cfg.normalization_layer_epsilon,
     )(intermediate_inputs)
     hidden_states = nn.with_logical_constraint(hidden_states, ("activation_batch", "activation_length", "activation_embed"))

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -73,7 +73,7 @@ class DecoderLayer(nn.Module):
         weight_dtype=cfg.weight_dtype,
         name="pre_self_attention_norm",
         epsilon=cfg.normalization_layer_epsilon,
-        kernel_axes=("embed",),
+        kernel_axes=("norm",),
     )(inputs)
     lnx = nn.with_logical_constraint(lnx, ("activation_batch", "activation_length", "activation_embed"))
 

--- a/MaxText/maxengine.py
+++ b/MaxText/maxengine.py
@@ -83,7 +83,8 @@ class MaxEngine(engine_api.Engine):
         lambda x: jax.ShapeDtypeStruct(shape=x.shape, dtype=x.dtype, sharding=x.sharding), state.params
     )
     self.kv_cache_annotations = max_utils.get_kv_cache_annotations(self.model, self.config, self.rng, self._mesh)
-    self.kv_cache_shardings = jax.tree_util.tree_map(lambda x: jax.sharding.NamedSharding(self._mesh, x), self.kv_cache_annotations)
+    self.kv_cache_shardings = jax.tree_util.tree_map(
+      lambda x: jax.sharding.NamedSharding(self._mesh, x), self.kv_cache_annotations)
 
     if not self.model.quant:
       self.abstract_params = jax.tree_util.tree_map(


### PR DESCRIPTION
This change is to switch the norm layer's sharding from "embed"/FSDP to match the "activation_embed"/tensor parallelism, aligning the sharding for [the element-wise multiplication](https://github.com/google/maxtext/blob/18ba1a7d0e68394ea6c0c394ab53b246c6672d9f/MaxText/layers/normalizations.py#L51)

* boosted multislice MFU by roughly 10% with TP activated after avoiding unexpected cross-slice DCN collective-permute caused by sharding mismatch [experiments](https://docs.google.com/spreadsheets/d/1w0a23CFGKMajxQgWojfptStv0nwdNmocTc3XNWeoihQ/edit?resourcekey=0-QPp_KP-Sq0wXj7KyHowHWw#gid=0)
* verified in HLOs
```
# Setup [data_dcn, fsdp_ici, tensor_ici] corresponds to [2,16,4] 

# norm weight (scale) was sharded by "embed"/fsdp i.e. 16 way fsdp sharding

reshape.371 = bf16[12288]{0} reshape(add.49), sharding={devices=[16,8]<=[2,16,4]T(1,0,2) last_tile_dim_replicate}, metadata={op_name="jit(train_step)/jit(main)/transpose(jvp(Transformer))/decoder/while/body/checkpoint/rematted_computation/layers/pre_self_attention_norm/add" source_file="/app/maxtext/MaxText/layers/gpt3.py" source_line=91}


# to ensure the same sharding as activation ((data, fsdp), None, tensor)
# expensive all gather and collective permuate communication triggered by sharding mismatch in broadcast: [16(fsdp),8(None)] -> [32(data x fsdp),1(None),4(tp)]

broadcast.1326 = bf16[128,2048,12288]{2,1,0} broadcast(reshape.371), dimensions={2}, sharding={devices=[32,1,4]<=[128]}, metadata={op_name="jit(train_step)/jit(main)/transpose(jvp(Transformer))/decoder/while/body/checkpoint/rematted_computation/layers/pre_self_attention_norm/mul" source_file="/app/maxtext/MaxText/layers/gpt3.py" source_line=91}
multiply.1327 = bf16[128,2048,12288]{2,1,0} multiply(multiply.1320, broadcast.1326), sharding={devices=[32,1,4]<=[128]}, metadata={op_name="jit(train_step)/jit(main)/transpose(jvp(Transformer))/decoder/while/body/checkpoint/rematted_computation/layers/pre_self_attention_norm/mul" source_file="/app/maxtext/MaxText/layers/gpt3.py" source_line=91}
```