### PR TITLE
 Add more tests for Mixtral

### DIFF
--- a/end_to_end/tpu/mixtral/8x7b/1_test_mixtral.sh
+++ b/end_to_end/tpu/mixtral/8x7b/1_test_mixtral.sh
@@ -2,7 +2,7 @@
 
 # This file, combined with step 2 in the same directory, runs on daily basis and demonstrates:
 # 1. Converts the Mistral PyTorch checkpoint to MaxText(orbax) format using a CPU VM.
-# 2. Takes the MaxText (orbax) checkpoint to run inference and fine-tuning on a TPU VM.
+# 2. Takes the MaxText(orbax) checkpoint to run inference, fine-tuning, and pre-training on a TPU VM.
 
 # The flow of this file is to convert the Mistral PyTorch checkpoint to MaxText (orbax) format using a CPU VM.
 
@@ -18,8 +18,16 @@ if [ -z "${BASE_OUTPUT_PATH}" ]; then
     echo "BASE_OUTPUT_PATH is not set, using BASE_OUTPUT_PATH = ${BASE_OUTPUT_PATH}"
 fi
 
-# Download checkpoint, convert it to MaxText(orbax) format
+# Download checkpoint
 pip3 install torch
 gcloud storage cp -r gs://maxtext-external/mixtral-8x7B-v0.1-Instruct /tmp
-JAX_PLATFORMS=cpu python3 MaxText/llama_or_mistral_ckpt.py --base-model-path /tmp/mixtral-8x7B-v0.1-Instruct --model-size mixtral-8x7b --maxtext-model-path ${BASE_OUTPUT_PATH}${MODEL_VARIATION}/decode-ckpt-maxtext/
-echo "Wrote MaxText compatible checkpoint to ${BASE_OUTPUT_PATH}${MODEL_VARIATION}/decode-ckpt-maxtext"
+
+# Convert it to MaxText(orbax) format - scanned ckpt
+JAX_PLATFORMS=cpu python3 MaxText/llama_or_mistral_ckpt.py --base-model-path /tmp/mixtral-8x7B-v0.1-Instruct --model-size mixtral-8x7b --maxtext-model-path ${BASE_OUTPUT_PATH}${MODEL_VARIATION}/scanned_ckpt/
+echo "Wrote MaxText compatible scanned checkpoint to ${BASE_OUTPUT_PATH}${MODEL_VARIATION}/scanned_ckpt"
+
+# Generate unscanned ckpt for efficient decoding test
+export SCANNED_CHECKPOINT=${BASE_OUTPUT_PATH}${MODEL_VARIATION}/scanned_ckpt/0/items
+export RUN_NAME=unscanned_ckpt
+JAX_PLATFORMS=cpu python MaxText/generate_param_only_checkpoint.py MaxText/configs/base.yml async_checkpointing=false base_output_directory=${BASE_OUTPUT_PATH} load_parameters_path=${SCANNED_CHECKPOINT} run_name=${RUN_NAME} model_name='mixtral-8x7b' force_unroll=true
+echo "Wrote MaxText compatible unscanned checkpoint to ${BASE_OUTPUT_PATH}/${RUN_NAME}/checkpoints"


### PR DESCRIPTION
# Description

Add 2 more Mixtral tests per [PR](https://github.com/google/maxtext/pull/616)'s request (along with this [PR](https://github.com/GoogleCloudPlatform/ml-auto-solutions/pull/272)):
* to generate unscanned ckpt
* to run pre-training

Note: I was not able to get it work for decoding with unscanned ckpt on multihosts. I got a few interesting errors below. Asked in the group chat, and it seems no clue yet. 

So add a TODO in the test script first, and take a deep look.

```
Error from try #1:
2024-04-30 03:13:45.121096: I external/xla/xla/pjrt/distributed/client.cc:134] Distributed task shutdown initiated.
2024-04-30 03:13:45.122686: I external/xla/xla/pjrt/distributed/client.cc:136] Distributed task shutdown result: OK
2024-04-30 03:13:45.122715: I external/tsl/tsl/distributed_runtime/preemption/preemption_sync_manager.cc:168] Cancelled call to retrieve preemption notice. This is expected upon program shutdown.

Error from try #2:
[2024-04-28, 05:35:50 UTC] {xpk.py:157} INFO - W0000 00:00:1714282001.278761    9853 curl_transport.cc:394] Error [56]=Failure when receiving data from the peer in curl operation
```

# Test

Upload to Airflow, and test passes - [link](https://screenshot.googleplex.com/AKYfbYmVNS8qRVa)