### PR TITLE
loosen tolerance in assert_params_sufficiently_sharded

### DIFF
--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -145,7 +145,7 @@ def calculate_prefill_tflops_per_device(num_model_parameters, prefill_length, co
   return total_tflops, learnable_weight_tflops, causal_attention_tflops
 
 
-def assert_params_sufficiently_sharded(params, mesh, tolerance=0.01):
+def assert_params_sufficiently_sharded(params, mesh, tolerance=0.02):
   """Checks whether most params are sharded across sharding axis.
 
   This function determines whether the majority of parameters  are distributed


### PR DESCRIPTION
* problem
Got the `params not sufficiently sharded` error in `maxtext-stable-gpt3-v4-8` test. The new ratio of 0.01006 slightly exceeds the limit of 0.01, which was 0.0064.
```
# total_num_params_per_chip / perfectly_sharded_params_per_chip - 1 =  0.01006
 File "/deps/MaxText/maxtext_utils.py", line 174, in assert_params_sufficiently_sharded
assert total_num_params_per_chip / perfectly_sharded_params_per_chip - 1 < tolerance, (
AssertionError: Number of unsharded parameters exceeds tolerance 1.0% of total parameters.
```

This is relevant to [the norm layer's sharding change from "embed"/FSDP to match the "activation_embed"/tensor parallelism](https://github.com/google/maxtext/pull/623). And in the special case tensor parallelism = 1, norm layer is simply replicated, which increase the ratio.

* solution
Expanding the acceptable threshold in this change.


