### PR TITLE
fix norm sharding in decoder_norm

### DIFF
--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -315,7 +315,7 @@ class Decoder(nn.Module):
         weight_dtype=cfg.weight_dtype,
         name="decoder_norm",
         epsilon=cfg.normalization_layer_epsilon,
-        kernel_axes=("embed",),
+        kernel_axes=("norm",),
     )(y)
     y = nn.Dropout(rate=cfg.dropout_rate, broadcast_dims=(-2,))(y, deterministic=deterministic)
 


### PR DESCRIPTION
During rebasing, the `decoder_norm` was unintentionally not covered in the PR https://github.com/google/maxtext/pull/623