### PR TITLE
Update tflops calculation

### DIFF
--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -91,30 +91,59 @@ def load_compiled(config, partial_train, state):
   return p_train_step
 
 
-# https://arxiv.org/pdf/2204.02311.pdf Appendix B
-def calculate_tflops_training_per_device(num_model_parameters, config, log=True):
+def calculate_tflops_training_per_device(config, log=True):
   """Calculate training TFLOP"""
-  learnable_weight_tflops = 6 * num_model_parameters * config.max_target_length * config.per_device_batch_size / 10**12
-  noncasual_attention_flops = (
-      12
-      * config.num_query_heads
-      * config.num_decoder_layers
-      * config.head_dim
-      * config.max_target_length**2
+  ffn1_flops = (
+      2
       * config.per_device_batch_size
-      / 10**12
+      * config.max_target_length
+      * config.mlp_dim
+      * config.emb_dim
+      * len(config.mlp_activations)
   )
-  causal_attention_tflops = noncasual_attention_flops / 2  # due to causality in attention
-  total_tflops = learnable_weight_tflops + causal_attention_tflops
+  ffn2_flops = 2 * config.per_device_batch_size * config.max_target_length * config.mlp_dim * config.emb_dim
+  total_ffn_flops = ffn1_flops + ffn2_flops
+
+  if config.num_experts > 1:
+    # MoE: brute force implementation
+    gate_flops = 2 * config.per_device_batch_size * config.max_target_length * config.emb_dim * config.num_experts
+    total_ffn_flops = gate_flops + config.num_experts * total_ffn_flops
+
+  qkv_flops = (
+      2
+      * config.per_device_batch_size
+      * config.max_target_length
+      * config.emb_dim
+      * (config.num_query_heads + 2 * config.num_kv_heads)
+      * config.head_dim
+  )
+  attention_flops = (
+      4 * config.per_device_batch_size * config.max_target_length**2 * config.num_query_heads * config.head_dim
+  )
+  projection_flops = (
+      2 * config.per_device_batch_size * config.max_target_length * config.emb_dim * config.num_query_heads * config.head_dim
+  )
+  embedding_flops = 2 * config.per_device_batch_size * config.max_target_length * config.emb_dim * config.vocab_size
+
+  # multiply by 3 for both feed forward and back proporgation flops
+  learnable_weight_tflops = (
+      ((total_ffn_flops + qkv_flops + projection_flops) * config.num_decoder_layers + embedding_flops) * 3 / 10**12
+  )
+  # megatron tflops calculation does not account for causality in attention
+  attention_tflops = (
+      attention_flops * config.num_decoder_layers * 3 / 10**12
+  )
+
+  total_tflops = learnable_weight_tflops + attention_tflops
 
   if log:
     print(
         "Per train step:\n",
         f"Total TFLOPs: {total_tflops:.2f} \n",
         f"split as {100 * learnable_weight_tflops/total_tflops:.2f}% learnable weight flops",
-        f"and {100 * causal_attention_tflops/total_tflops:.2f}% attention flops",
+        f"and {100 * attention_tflops/total_tflops:.2f}% attention flops",
     )
-  return total_tflops, learnable_weight_tflops, causal_attention_tflops
+  return total_tflops, learnable_weight_tflops, attention_tflops
 
 
 # https://arxiv.org/pdf/2204.02311.pdf Appendix B
@@ -135,12 +164,12 @@ def calculate_prefill_tflops_per_device(num_model_parameters, prefill_length, co
 
   if log:
     print(
-      "Per prefill step per device: \n",
-      f"\tTotal TFLOPs: {total_tflops:.2f} \n",
-      f"\t\tLearnable weight TFLOPs: {learnable_weight_tflops:.2f} ",
-      f"({100 * learnable_weight_tflops/total_tflops:.2f})% of Total\n",
-      f"\t\tCausal attention TFLOPs: {causal_attention_tflops:.2f} ",
-      f"({100 * causal_attention_tflops/total_tflops:.2f})% of Total",
+        "Per prefill step per device: \n",
+        f"\tTotal TFLOPs: {total_tflops:.2f} \n",
+        f"\t\tLearnable weight TFLOPs: {learnable_weight_tflops:.2f} ",
+        f"({100 * learnable_weight_tflops/total_tflops:.2f})% of Total\n",
+        f"\t\tCausal attention TFLOPs: {causal_attention_tflops:.2f} ",
+        f"({100 * causal_attention_tflops/total_tflops:.2f})% of Total",
     )
   return total_tflops, learnable_weight_tflops, causal_attention_tflops
 

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -445,7 +445,7 @@ def train_loop(config, state=None):
 
   num_model_parameters = max_utils.calculate_num_params_from_pytree(state.params)
   max_logging.log(f"number parameters: {num_model_parameters/1e9:.3f} billion")
-  per_device_tflops, _, _ = maxtext_utils.calculate_tflops_training_per_device(num_model_parameters, config)
+  per_device_tflops, _, _ = maxtext_utils.calculate_tflops_training_per_device(config)
 
   # Write train config params, num model params, and XLA flags to tensorboard
   max_utils.add_text_to_summary_writer("num_model_parameters", str(num_model_parameters), writer)


### PR DESCRIPTION
# Description

Update tflops calculation to match Megatron style with sources:
* MaxText reference [PR](https://github.com/google/maxtext/pull/537/files)
* Megatron-LM [link](https://github.com/NVIDIA/Megatron-LM/blob/db3a3f79d1cda60ea4b3db0ceffcf20c5760e11d/megatron/training/training.py#L68)

# Test 

List models before/after the change: `total_ffn_flops` value

| Model Name | TFLOPS/step before | TFLOPS/step after|
| -------- | ------- | ------|
| llama2-7b | 1033.2 | 1053.4 |
| llama2-13b | 1981.1 | 2018.7 |
| mistral-7b | 1107.4 | 1127.6 |
| llama2-70b | 10368.9 | 10528.0 |
| mixtral-8x7b | 6926.1 |  6946.5 |
| gemma-7b |  1293.6 | 1328.2 |
| gemma-2b | 380.7 | 391.8 |
| gpt3-6b | 423.1 | 430.4 |
| gpt3-52k | 0.01256 | 0.01253 |


Test code snippet

```
class FlopsTest(unittest.TestCase):

  def setUp(self):
    import os
    os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
    pyconfig.initialize(
      [None, 'configs/base.yml'],
      run_name='test',
      model_name='mixtral-8x7b',
      flops_change=False,
    )
    self.cfg = pyconfig.config
    devices_array = max_utils.create_device_mesh(self.cfg)
    self.mesh = Mesh(devices_array, self.cfg.mesh_axes)
    quant = quantizations.configure_quantization(self.cfg)
    self.model = Transformer(self.cfg, mesh=self.mesh, quant=quant)

  def test_flops(self):
    rng = random.PRNGKey(0)

    tx = optax.adam(learning_rate=0.001)
    state, _, _ = max_utils.setup_training_state(self.model, None, tx, self.cfg, rng, self.mesh, None)
    num_model_parameters = max_utils.calculate_num_params_from_pytree(state.params)
    maxtext_utils.calculate_tflops_training_per_device(num_model_parameters, self.cfg)
```
