### PR TITLE
Update the NCCL flags for A3+.

### DIFF
--- a/gpu_multi_process_run.sh
+++ b/gpu_multi_process_run.sh
@@ -45,29 +45,26 @@ set_nccl_gpudirect_tcpx_specific_configuration() {
     export NCCL_NVLS_ENABLE=0
   elif [[ "$USE_GPUDIRECT" == "fastrak" ]]; then
     echo "Using GPUDirect-TCPFasTrak"
-    export NCCL_DEBUG_SUBSYS=INIT,GRAPH,ENV,TUNING,NET,VERSION
-    export NCCL_DEBUG=INFO
-    export NCCL_FASTRAK_ENABLE_HOTPATH_LOGGING=0
-    export LD_LIBRARY_PATH="/usr/local/fastrak/lib64:${LD_LIBRARY_PATH}"
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/tcpxo/lib64"
     export NCCL_FASTRAK_CTRL_DEV=eth0
     export NCCL_FASTRAK_IFNAME=eth1,eth2,eth3,eth4,eth5,eth6,eth7,eth8
     export NCCL_SOCKET_IFNAME=eth0
     export NCCL_CROSS_NIC=0
     export NCCL_ALGO=Ring
     export NCCL_PROTO=Simple
-    export NCCL_MAX_NCHANNELS=16
-    export NCCL_MIN_NCHANNELS=16
-    export NCCL_SOCKET_NTHREADS=4
-    export NCCL_DYNAMIC_CHUNK_SIZE=524288
+    export NCCL_MIN_NCHANNELS=4
     export NCCL_DYNAMIC_CHUNK_SIZE=524288
     export NCCL_P2P_NET_CHUNKSIZE=524288
     export NCCL_P2P_PCI_CHUNKSIZE=524288
     export NCCL_P2P_NVL_CHUNKSIZE=1048576
-    export NCCL_FASTRAK_NUM_FLOWS=8
-    export NCCL_FASTRAK_FLOWS_PER_GROUP=2
-    export NCCL_BUFFSIZE=4194304
+    export NCCL_FASTRAK_NUM_FLOWS=2
+    export NCCL_FASTRAK_USE_SNAP=1
+    export NCCL_FASTRAK_ENABLE_CONTROL_CHANNEL=0
+    export NCCL_BUFFSIZE=8388608
     export CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7
     export NCCL_NET_GDR_LEVEL=PIX
+    export NCCL_FASTRAK_ENABLE_HOTPATH_LOGGING=0
+    export NCCL_FASTRAK_USE_LLCM=1
   else
     echo "NOT using GPUDirect"
   fi


### PR DESCRIPTION
End-to-end test passed: first created an A3+ cluster including 2 nodes and then run MaxText at 2 nodes.