### PR TITLE
integrate nsys profiler into MaxText

### DIFF
--- a/MaxText/configs/a3/llama_2_7b/16vm.sh
+++ b/MaxText/configs/a3/llama_2_7b/16vm.sh
@@ -39,4 +39,4 @@ export XLA_FLAGS="--xla_dump_to=$OUTPUT_PATH/$RUN_NAME/HLO_dumps/
 python MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME hardware=gpu \
     steps=30 dcn_data_parallelism=16 ici_fsdp_parallelism=8 per_device_batch_size=4 max_target_length=4096 model_name=llama2-7b \
     enable_checkpointing=false attention=cudnn_flash_te remat_policy=minimal_flash use_iota_embed=true scan_layers=false \
-    dataset_type=synthetic async_checkpointing=false base_output_directory=gs://runner-maxtext-logs enable_profiler=true
+    dataset_type=synthetic async_checkpointing=false base_output_directory=gs://runner-maxtext-logs profiler=xplane

--- a/MaxText/configs/a3/llama_2_7b/1vm.sh
+++ b/MaxText/configs/a3/llama_2_7b/1vm.sh
@@ -39,4 +39,4 @@ export XLA_FLAGS="--xla_dump_to=$OUTPUT_PATH/$RUN_NAME/HLO_dumps/
 python MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME hardware=gpu\
     steps=30 dcn_data_parallelism=1 ici_fsdp_parallelism=8 per_device_batch_size=4 max_target_length=4096 model_name=llama2-7b \
     enable_checkpointing=false attention=cudnn_flash_te remat_policy=minimal_flash use_iota_embed=true scan_layers=false \
-    dataset_type=synthetic async_checkpointing=false base_output_directory=$OUTPUT_PATH enable_profiler=false
+    dataset_type=synthetic async_checkpointing=false base_output_directory=$OUTPUT_PATH

--- a/MaxText/configs/a3/llama_2_7b/2vm.sh
+++ b/MaxText/configs/a3/llama_2_7b/2vm.sh
@@ -40,5 +40,5 @@ export XLA_FLAGS="--xla_dump_to=$OUTPUT_PATH/$RUN_NAME/HLO_dumps/
 python MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME hardware=gpu \
     steps=30 dcn_data_parallelism=2 ici_fsdp_parallelism=8 per_device_batch_size=4 max_target_length=4096 model_name=llama2-7b \
     enable_checkpointing=false attention=cudnn_flash_te remat_policy=minimal_flash use_iota_embed=true scan_layers=false \
-    dataset_type=synthetic async_checkpointing=false base_output_directory=gs://runner-maxtext-logs enable_profiler=true
+    dataset_type=synthetic async_checkpointing=false base_output_directory=gs://runner-maxtext-logs profiler=xplane
 

--- a/MaxText/configs/a3/llama_2_7b/4vm.sh
+++ b/MaxText/configs/a3/llama_2_7b/4vm.sh
@@ -38,5 +38,5 @@ export XLA_FLAGS="--xla_dump_to=$OUTPUT_PATH/$RUN_NAME/HLO_dumps/
 python MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME hardware=gpu \
     steps=30 dcn_data_parallelism=4 ici_fsdp_parallelism=8 per_device_batch_size=4 max_target_length=4096 model_name=llama2-7b \
     enable_checkpointing=false attention=cudnn_flash_te remat_policy=minimal_flash use_iota_embed=true scan_layers=false \
-    dataset_type=synthetic async_checkpointing=false base_output_directory=gs://runner-maxtext-logs enable_profiler=true
+    dataset_type=synthetic async_checkpointing=false base_output_directory=gs://runner-maxtext-logs profiler=xplane
     

--- a/MaxText/configs/a3/llama_2_7b/8vm.sh
+++ b/MaxText/configs/a3/llama_2_7b/8vm.sh
@@ -39,5 +39,5 @@ export XLA_FLAGS="--xla_dump_to=$OUTPUT_PATH/$RUN_NAME/HLO_dumps/
 python MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME hardware=gpu \
     steps=30 dcn_data_parallelism=8 ici_fsdp_parallelism=8 per_device_batch_size=4 max_target_length=4096 model_name=llama2-7b \
     enable_checkpointing=false attention=cudnn_flash_te remat_policy=minimal_flash use_iota_embed=true scan_layers=false \
-    dataset_type=synthetic async_checkpointing=false base_output_directory=gs://runner-maxtext-logs enable_profiler=true
+    dataset_type=synthetic async_checkpointing=false base_output_directory=gs://runner-maxtext-logs profiler=xplane
     

--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -206,8 +206,10 @@ load_from_prefill_dir: False # If true, decode.py doesn't "prefill" but just rea
 prefill_cache_dir: "" # If set and load_from_prefill_dir, decode.py reads from directory. If set, decode.py writes to directory
 autoregressive_decode_assert: ""
 
-enable_profiler: False
-# If set to true, upload all profiler xplane results from all hosts. Otherwise, only upload the xplane result from the first host.
+# For nsys profiler, pass the training command to nsys command
+# e.g. nsys profile -s none --force-overwrite true --capture-range=cudaProfilerApi --capture-range-end=stop {training command} 
+profiler: "" # Supported profiler: '', xplane, nsys
+# If set to true, upload all profiler results from all hosts. Otherwise, only upload the profiler result from the first host.
 upload_all_profiler_results: False
 # Skip first n steps for profiling, to omit things like compilation and to give
 # the iteration time a chance to stabilize.

--- a/MaxText/configs/experimental/1024b.sh
+++ b/MaxText/configs/experimental/1024b.sh
@@ -21,7 +21,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
     steps=20 per_device_batch_size=2 enable_checkpointing=false\
-    enable_profiler=false remat_policy=full global_parameter_scale=1024\
+    remat_policy=full global_parameter_scale=1024\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=16\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/configs/experimental/128b.sh
+++ b/MaxText/configs/experimental/128b.sh
@@ -21,7 +21,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
     steps=30 per_device_batch_size=2 enable_checkpointing=false\
-    enable_profiler=false remat_policy=minimal global_parameter_scale=128\
+    remat_policy=minimal global_parameter_scale=128\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=8\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/configs/experimental/256b.sh
+++ b/MaxText/configs/experimental/256b.sh
@@ -21,7 +21,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
     steps=20 per_device_batch_size=2 enable_checkpointing=false\
-    enable_profiler=false remat_policy=minimal global_parameter_scale=256\
+    remat_policy=minimal global_parameter_scale=256\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=8\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/configs/experimental/32b.sh
+++ b/MaxText/configs/experimental/32b.sh
@@ -21,7 +21,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
     steps=30 per_device_batch_size=8 enable_checkpointing=false\
-    enable_profiler=false remat_policy=minimal global_parameter_scale=32\
+    remat_policy=minimal global_parameter_scale=32\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=4\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/configs/experimental/512b.sh
+++ b/MaxText/configs/experimental/512b.sh
@@ -21,7 +21,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
     steps=20 per_device_batch_size=2 enable_checkpointing=false\
-    enable_profiler=false remat_policy=full global_parameter_scale=512\
+    remat_policy=full global_parameter_scale=512\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=16\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/configs/experimental/64b.sh
+++ b/MaxText/configs/experimental/64b.sh
@@ -21,7 +21,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
     steps=30 per_device_batch_size=4 enable_checkpointing=false\
-    enable_profiler=false remat_policy=minimal global_parameter_scale=64\
+    remat_policy=minimal global_parameter_scale=64\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=4\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/configs/v4/22b.sh
+++ b/MaxText/configs/v4/22b.sh
@@ -55,6 +55,6 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
-    ici_fsdp_parallelism=64 steps=10 per_device_batch_size=13 enable_profiler=true remat_policy=full\
+    ici_fsdp_parallelism=64 steps=10 per_device_batch_size=13 profiler=xplane remat_policy=full\
     base_emb_dim=6144 base_num_kv_heads=24 base_num_query_heads=24 base_mlp_dim=24576 base_num_decoder_layers=48\
     base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH 

--- a/MaxText/configs/v4/52b.sh
+++ b/MaxText/configs/v4/52b.sh
@@ -55,7 +55,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
-    enable_profiler=true enable_checkpointing=false steps=10\
+    profiler=xplane enable_checkpointing=false steps=10\
     ici_fsdp_parallelism=192 ici_tensor_parallelism=1 per_device_batch_size=7 remat_policy=full\
     base_num_decoder_layers=32 base_emb_dim=12288 base_mlp_dim=49152 base_num_query_heads=32 base_num_kv_heads=32 learning_rate=1e-8\
     base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH

--- a/MaxText/configs/v5e/128b.sh
+++ b/MaxText/configs/v5e/128b.sh
@@ -43,7 +43,7 @@ export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xl
 
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=30 per_device_batch_size=1 enable_checkpointing=false\
-    enable_profiler=false remat_policy=qkv_proj_offloaded global_parameter_scale=128\
+    remat_policy=qkv_proj_offloaded global_parameter_scale=128\
     ici_fsdp_parallelism=16 ici_tensor_parallelism=16\
     max_target_length=2048 base_output_directory=gs://runner-maxtext-logs\
     use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/configs/v5e/16b.sh
+++ b/MaxText/configs/v5e/16b.sh
@@ -42,7 +42,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=30 per_device_batch_size=6 enable_checkpointing=false\
-    enable_profiler=false remat_policy=full global_parameter_scale=16\
+    remat_policy=full global_parameter_scale=16\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\
     dataset_type=synthetic attention='flash' gcs_metrics=true 

--- a/MaxText/configs/v5e/32b.sh
+++ b/MaxText/configs/v5e/32b.sh
@@ -42,7 +42,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=30 per_device_batch_size=4 enable_checkpointing=false\
-    enable_profiler=false remat_policy=full global_parameter_scale=32\
+    remat_policy=full global_parameter_scale=32\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\
     dataset_type=synthetic attention='flash' gcs_metrics=true

--- a/MaxText/configs/v5e/64b.sh
+++ b/MaxText/configs/v5e/64b.sh
@@ -42,7 +42,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=30 per_device_batch_size=2 enable_checkpointing=false\
-    enable_profiler=false remat_policy=full global_parameter_scale=64\
+    remat_policy=full global_parameter_scale=64\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\
     dataset_type=synthetic attention='flash' gcs_metrics=true

--- a/MaxText/configs/v5p/1024b.sh
+++ b/MaxText/configs/v5p/1024b.sh
@@ -42,7 +42,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=20 per_device_batch_size=2 enable_checkpointing=false\
-    enable_profiler=false remat_policy=full global_parameter_scale=1024\
+    remat_policy=full global_parameter_scale=1024\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=16\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/configs/v5p/128b.sh
+++ b/MaxText/configs/v5p/128b.sh
@@ -42,7 +42,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=30 per_device_batch_size=1 enable_checkpointing=false\
-    enable_profiler=false remat_policy=minimal global_parameter_scale=128\
+    remat_policy=minimal global_parameter_scale=128\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=8\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/configs/v5p/256b.sh
+++ b/MaxText/configs/v5p/256b.sh
@@ -42,7 +42,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=20 per_device_batch_size=1 enable_checkpointing=false\
-    enable_profiler=false remat_policy=minimal global_parameter_scale=256\
+    remat_policy=minimal global_parameter_scale=256\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=8\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/configs/v5p/32b.sh
+++ b/MaxText/configs/v5p/32b.sh
@@ -42,7 +42,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=30 per_device_batch_size=6 enable_checkpointing=false\
-    enable_profiler=false remat_policy=minimal global_parameter_scale=32\
+    remat_policy=minimal global_parameter_scale=32\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=4\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/configs/v5p/512b.sh
+++ b/MaxText/configs/v5p/512b.sh
@@ -42,7 +42,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=20 per_device_batch_size=2 enable_checkpointing=false\
-    enable_profiler=false remat_policy=full global_parameter_scale=512\
+    remat_policy=full global_parameter_scale=512\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=8\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/configs/v5p/64b.sh
+++ b/MaxText/configs/v5p/64b.sh
@@ -42,7 +42,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=30 per_device_batch_size=3 enable_checkpointing=false\
-    enable_profiler=false remat_policy=minimal global_parameter_scale=64\
+    remat_policy=minimal global_parameter_scale=64\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=4\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/inference_microbenchmark.py
+++ b/MaxText/inference_microbenchmark.py
@@ -25,6 +25,7 @@ from jetstream.engine import token_utils
 import max_utils
 import maxengine
 import maxtext_utils
+import profiler
 import pyconfig
 
 
@@ -73,7 +74,8 @@ def prefill_insert_benchmark_loop(
     config, engine, decode_state, params, total_slots, tokens, true_length, iters, profile_name
   ):
   """Inner loop for benchmarking prefill and insert step."""
-  max_utils.activate_profiler(config, profile_name)
+  prof = profiler.Profiler(config, profile_name)
+  prof.activate()
   start = datetime.datetime.now()
   for i in range(iters):
     prefill_result = engine.prefill(params=params, padded_tokens=tokens, true_length=true_length)
@@ -81,7 +83,7 @@ def prefill_insert_benchmark_loop(
     max_utils.delete_pytree(prefill_result)
   jax.block_until_ready(decode_state)
   end = datetime.datetime.now()
-  max_utils.deactivate_profiler(config)
+  prof.deactivate()
   return (end - start).total_seconds(), decode_state
 
 
@@ -111,13 +113,14 @@ def prefill_insert_benchmark(
 
 def ar_benchmark_loop(config, engine, params, decode_state, iters, profile_name):
   """Inner loop for benchmarking ar step."""
-  max_utils.activate_profiler(config, profile_name)
+  prof = profiler.Profiler(config, profile_name)
+  prof.activate()
   start = datetime.datetime.now()
   for _ in range(iters):
     decode_state, _ = engine.generate(params, decode_state)
   jax.block_until_ready(decode_state)
   end = datetime.datetime.now()
-  max_utils.deactivate_profiler(config)
+  prof.deactivate()
   return (end - start).total_seconds(), decode_state
 
 

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -86,18 +86,6 @@ def summarize_size_from_pytree(params):
   num_bytes = calculate_bytes_from_pytree(params)
   return num_params, num_bytes, num_bytes / num_params
 
-
-def activate_profiler(config, optional_postfix=""):
-  if config.enable_profiler and (config.upload_all_profiler_results or jax.process_index() == 0):
-    output_path = os.path.join(config.tensorboard_dir, optional_postfix)
-    jax.profiler.start_trace(output_path)
-
-
-def deactivate_profiler(config):
-  if config.enable_profiler and (config.upload_all_profiler_results or jax.process_index() == 0):
-    jax.profiler.stop_trace()
-
-
 def initialize_summary_writer(config):
   return writer.SummaryWriter(config.tensorboard_dir) if jax.process_index() == 0 else None
 

--- a/MaxText/profiler.py
+++ b/MaxText/profiler.py
@@ -1,0 +1,67 @@
+"""
+Copyright 2024 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+"""Dispatch to the chosen profiler"""
+from ctypes import cdll
+import os
+import subprocess
+
+import max_logging
+
+import jax
+
+class Profiler:
+  """Activate/deactivate a profiler based on the 'profiler' config"""
+
+  def __init__(self, config, optional_postfix=""):
+    self.libcudart = None
+    self.mode = config.profiler
+    self.upload_all_profiler_results = config.upload_all_profiler_results
+    if self.mode != "":
+      self.output_path = os.path.join(config.tensorboard_dir, optional_postfix)
+
+  def activate(self):
+    """Start the profiler.
+    nsys profiler becomes no-op when libcudart.so is not available on the system"""
+    if not (self.upload_all_profiler_results or jax.process_index() == 0):
+      return
+    if self.mode == "nsys":
+      try:
+        self.libcudart = cdll.LoadLibrary('libcudart.so')
+      except Exception as e: # pylint: disable=broad-except
+        max_logging.log(f"WARNING: Failed to load library for nsys: {e}\n"
+                        "profiler has no effect")
+        return
+      self.libcudart.cudaProfilerStart()
+    elif self.mode == "xplane":
+      jax.profiler.start_trace(self.output_path)
+
+  def deactivate(self):
+    """End the profiler.
+    The result is uploaded to the output bucket"""
+    if not (self.upload_all_profiler_results or jax.process_index() == 0):
+      return
+    if self.mode == "nsys":
+      if self.libcudart is not None:
+        self.libcudart.cudaProfilerStop()
+      else:
+        max_logging.log("WARNING: library for nsys was not loaded \n"
+                        "profiler has no effect")
+        return
+      # Popen() instead of run() for non-blocking behavior
+      subprocess.Popen(["gsutil", "cp", "*nsys-rep", self.output_path]) # pylint: disable=consider-using-with
+    elif self.mode == "xplane":
+      jax.profiler.stop_trace()

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -56,9 +56,15 @@ def validate_attention_type(s: str) -> None:
   if s not in valid_attention_types:  # currently supported attention
     raise ValueError("Invalid attention type was passed. Valid options ", valid_attention_types)
 
+def validate_profiler_type(s: str) -> None:
+  valid_profiler_types = ("", "nsys", "xplane")
+  if s not in valid_profiler_types:  # currently supported attention
+    raise ValueError("Invalid profiler type was passed. Valid options ", valid_profiler_types)
+
 
 def validate_keys(keys):
   validate_attention_type(keys["attention"])
+  validate_profiler_type(keys["profiler"])
 
   assert (keys["load_parameters_path"] == "" and keys["load_full_state_path"] == "") or keys[
       "enable_checkpointing"

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -39,6 +39,7 @@ import max_utils
 import maxtext_utils
 import max_logging
 import optimizers
+import profiler
 import pyconfig
 # pylint: disable-next=unused-import
 import register_jax_proxy_backend
@@ -486,16 +487,16 @@ def train_loop(config, state=None):
 
   start_step = get_first_step(state)  # this is the start_step for training
   first_profiling_step = start_step + config.skip_first_n_steps_for_profiler
-  if config.enable_profiler and first_profiling_step >= config.steps:
+  if config.profiler != "" and first_profiling_step >= config.steps:
     raise ValueError("Profiling requested but initial profiling step set past training final step")
   last_profiling_step = np.clip(first_profiling_step + config.profiler_steps - 1, first_profiling_step, config.steps - 1)
 
   example_batch = None
   last_step_completion = datetime.datetime.now()
-
+  prof = profiler.Profiler(config)
   for step in np.arange(start_step, config.steps):
     if step == first_profiling_step:
-      max_utils.activate_profiler(config)
+      prof.activate()
 
     with jax.profiler.StepTraceAnnotation("train", step_num=step):
       example_batch = load_next_batch(data_iterator, example_batch, config)
@@ -532,11 +533,11 @@ def train_loop(config, state=None):
       max_logging.log(f"average loss after {step=}: {eval_loss=}, total_weights={cumulative_eval_metrics['total_weights']}")
       if eval_loss <= config.target_eval_loss:
         max_logging.log(f"Early stop and exit loop after reaching {config.target_eval_loss=}")
-        max_utils.deactivate_profiler(config)
+        prof.deactivate()
         break
 
     if step == last_profiling_step:
-      max_utils.deactivate_profiler(config)
+      prof.deactivate()
 
   if checkpoint_manager is not None:
     checkpoint_manager.wait_until_finished()

--- a/end_to_end/gpu/a3/test_llama2_7b.sh
+++ b/end_to_end/gpu/a3/test_llama2_7b.sh
@@ -62,7 +62,7 @@ export XLA_FLAGS="--xla_dump_to=$BASE_OUTPUT_PATH/$RUN_NAME/HLO_dumps/
  --xla_gpu_enable_all_gather_combine_by_dim=false --xla_gpu_enable_reduce_scatter_combine_by_dim=false
  --xla_disable_hlo_passes=rematerialization"
 
-python MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME hardware=gpu steps=30 dcn_data_parallelism=1 ici_fsdp_parallelism=8 per_device_batch_size=4 max_target_length=4096 model_name=llama2-7b enable_checkpointing=true attention=cudnn_flash_te remat_policy=minimal_flash use_iota_embed=true scan_layers=false dataset_type=synthetic async_checkpointing=${ASYNC_CHECKPOINTING} base_output_directory=$BASE_OUTPUT_DIRECTORY enable_profiler=false
+python MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME hardware=gpu steps=30 dcn_data_parallelism=1 ici_fsdp_parallelism=8 per_device_batch_size=4 max_target_length=4096 model_name=llama2-7b enable_checkpointing=true attention=cudnn_flash_te remat_policy=minimal_flash use_iota_embed=true scan_layers=false dataset_type=synthetic async_checkpointing=${ASYNC_CHECKPOINTING} base_output_directory=$BASE_OUTPUT_DIRECTORY
 
 export XLA_PYTHON_CLIENT_MEM_FRACTION=0.65
 export TF_FORCE_GPU_ALLOW_GROWTH=true

--- a/end_to_end/tpu/test_convergence_1b_params.sh
+++ b/end_to_end/tpu/test_convergence_1b_params.sh
@@ -48,7 +48,7 @@ fi
 TRAIN_CMD="python3 MaxText/train.py MaxText/configs/base.yml\
         steps=$STEPS per_device_batch_size=8.0 learning_rate=3e-4 enable_checkpointing=false \
         max_target_length=2048 global_parameter_scale=1 \
-        enable_profiler=false metrics_file=metrics.txt base_output_directory=$OUTPUT_PATH\
+        metrics_file=metrics.txt base_output_directory=$OUTPUT_PATH\
         dataset_path=$DATASET_PATH log_period=150 remat_policy=minimal enable_data_shuffling=false"
 TRAIN_CMD+=$CMD_DATA
 

--- a/end_to_end/tpu/test_gpt3.sh
+++ b/end_to_end/tpu/test_gpt3.sh
@@ -11,6 +11,5 @@ python3 MaxText/convert_gpt3_ckpt_from_paxml.py --paxml-ckpt-path=${PAXML_CKPT_P
 # Run gpt3-52k with the converted ckpt
 python3 MaxText/train.py MaxText/configs/base.yml run_name=${RUN_NAME} model_name=gpt3-52k\
     steps=10 per_device_batch_size=6 enable_checkpointing=true async_checkpointing=false\
-    enable_profiler=false remat_policy=full\
-    max_target_length=2048 base_output_directory=${OUTPUT_PATH}\
+    remat_policy=full max_target_length=2048 base_output_directory=${OUTPUT_PATH}\
     dataset_type=synthetic

--- a/end_to_end/tpu/test_tflops.sh
+++ b/end_to_end/tpu/test_tflops.sh
@@ -16,7 +16,7 @@ fi
 
 #Train
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
-    steps=150 reuse_example_batch=1 remat_policy='full' enable_profiler=True enable_checkpointing=False metrics_file='metrics.txt'\
+    steps=150 reuse_example_batch=1 remat_policy='full' profiler=xplane enable_checkpointing=False metrics_file='metrics.txt'\
     base_output_directory=$OUTPUT_PATH dataset_path=$DATASET_PATH log_period=150
 
 python3 end_to_end/tpu/eval_assert.py metrics_average metrics.txt $TFLOP_THRESHOLD perf/per_device_tflops_per_sec

--- a/end_to_end/tpu/test_tflops_16b_params.sh
+++ b/end_to_end/tpu/test_tflops_16b_params.sh
@@ -29,8 +29,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
-    steps=150 per_device_batch_size=6 enable_checkpointing=false\
-    enable_profiler=false remat_policy=full\
+    steps=150 per_device_batch_size=6 enable_checkpointing=false remat_policy=full\
     max_target_length=2048 metrics_file='metrics.txt' base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH log_period=150 global_parameter_scale=16
 

--- a/end_to_end/tpu/test_tflops_32b_params.sh
+++ b/end_to_end/tpu/test_tflops_32b_params.sh
@@ -29,8 +29,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
-    steps=150 per_device_batch_size=4 enable_checkpointing=false\
-    enable_profiler=false remat_policy=full\
+    steps=150 per_device_batch_size=4 enable_checkpointing=false remat_policy=full\
     max_target_length=2048 metrics_file='metrics.txt' base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH log_period=150 global_parameter_scale=32
 

--- a/end_to_end/tpu/test_tflops_64b_params.sh
+++ b/end_to_end/tpu/test_tflops_64b_params.sh
@@ -29,8 +29,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/train.py MaxText/configs/base.yml run_name=$RUN_NAME\
-    steps=150 per_device_batch_size=2 enable_checkpointing=false\
-    enable_profiler=false remat_policy=full\
+    steps=150 per_device_batch_size=2 enable_checkpointing=false remat_policy=full\
     max_target_length=2048 metrics_file='metrics.txt' base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH log_period=150 global_parameter_scale=64
 


### PR DESCRIPTION
* "profiler" key is added to choose a profiler to use ("nsys", "xplane" or none) and is turned off by default.
  * When it's set to "nsys", it grabs `*nsys-rep` file and auto-uploads to the output bucket at the end of profiling.
  * Users still need to prepend `nsys` command in addition to setting `profiler=nsys`.
* "enable_profielr" config is removed and replace with "profiler" accordingly