### PR TITLE
Add flag for single controller workloads to avoid `jax.distributed.initialize()`

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -284,3 +284,6 @@ inference_microbenchmark_log_file_path: ""
 # Checkpoint Structured logging
 enable_checkpoint_cloud_logger: False
 enable_checkpoint_standard_logger: False
+
+# Single-controller
+enable_single_controller: False

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -205,7 +205,7 @@ def maybe_initialize_jax_distributed_system(raw_keys):
   For CPUs, we call jax.distributed.initialize() explicitly, with the specified arguments.
   """
   if (
-      raw_keys["enable_checkpointing"] and raw_keys["async_checkpointing"] and raw_keys["compile_topology_num_slices"] == -1
+      raw_keys["enable_checkpointing"] and raw_keys["async_checkpointing"] and raw_keys["compile_topology_num_slices"] == -1 and not raw_keys["enable_single_controller"]
   ) or raw_keys["hardware"] == "gpu_multiprocess":
     max_logging.log("Attempting to initialize the jax distributed system...")
     jax.distributed.initialize()


### PR DESCRIPTION
# Problem

Single controller workloads need to pass in `enable_checkpointing=true` and `async_checkpointing=true` to trigger async distributed checkpointing but will fail the `jax.distributed.initialize()` call.

# Change
Introduce a flag for single controller workloads which, if set to true, will block `jax.distributed.initialize()`