### PR TITLE
fix OUTPUT_PATH in v5e/128b.sh

### DIFF
--- a/MaxText/configs/v5e/128b.sh
+++ b/MaxText/configs/v5e/128b.sh
@@ -45,7 +45,7 @@ python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
     steps=30 per_device_batch_size=1 enable_checkpointing=false\
     remat_policy=qkv_proj_offloaded global_parameter_scale=128\
     ici_fsdp_parallelism=16 ici_tensor_parallelism=16\
-    max_target_length=2048 base_output_directory=gs://runner-maxtext-logs\
+    max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     use_iota_embed=true reuse_example_batch=1\
     dataset_type=synthetic attention='flash' gcs_metrics=true\
     fused_qkv=True fused_mlp=True\


### PR DESCRIPTION
Fix hardcoded OUTPUT_PATH `gs://runner-maxtext-logs` to a variable, following the same practice as other v5e scripts.