### PR TITLE
Update flops calculation to active experts in moe

### DIFF
--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -109,7 +109,7 @@ def calculate_tflops_training_per_device(config, log=True):
   if config.num_experts > 1:
     # MoE: brute force implementation
     gate_flops = 2 * config.per_device_batch_size * config.max_target_length * config.emb_dim * config.num_experts
-    total_ffn_flops = gate_flops + config.num_experts * total_ffn_flops
+    total_ffn_flops = gate_flops + config.num_experts_per_tok * total_ffn_flops
 
   qkv_flops = (
       2


### PR DESCRIPTION
# Description

Update TFLOPs calculation from number of total experts for each ffn to number of active experts, to match Megatron [calculation](https://github.com/NVIDIA/Megatron-LM/blob/c4d12e26b2dc25a2eab7da92e2ac30338c0ed3de/megatron/training/training.py#L99).

# Test

Before the change: 
* Mixtral 8x7b (2 out of 8 experts) - Total TFLOPs: 287.78

After the change:
 * Mixtral 8x7b - Total TFLOPs: 79.98
