### PR TITLE
Upgrade Pinned Base Image for GPU

### DIFF
--- a/docker_build_dependency_image.sh
+++ b/docker_build_dependency_image.sh
@@ -57,7 +57,7 @@ if [[ -z ${LIBTPU_GCS_PATH+x} ]] ; then
   echo "Default LIBTPU_GCS_PATH=${LIBTPU_GCS_PATH}"
   if [[ ${DEVICE} == "gpu" ]]; then
     if [[ ${MODE} == "pinned" ]]; then
-      export BASEIMAGE=ghcr.io/nvidia/jax:base-2024-03-13
+      export BASEIMAGE=ghcr.io/nvidia/jax:base-2024-05-07
     else
       export BASEIMAGE=ghcr.io/nvidia/jax:base
     fi


### PR DESCRIPTION
Per NVIDIA and my own testing, more recent Jax Base images for GPU have fixes that improves fp8 performance. Upgrading to a more recent one from early May that've seen good results with. 