### PR TITLE
Enable async checkpointing for GPU.

### DIFF
--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -192,17 +192,17 @@ def maybe_initialize_jax_distributed_system(raw_keys):
 
   For CPUs, we call jax.distributed.initialize() explicitly, with the specified arguments.
   """
-  if (
+  if is_gpu_backend(raw_keys):
+    max_logging.log("Attempting to initialize the jax distributed system for GPU backend...")
+    initialize_jax_for_gpu()
+    max_logging.log("Jax distributed system initialized on GPU!")
+  elif (
       raw_keys["enable_checkpointing"] and raw_keys["async_checkpointing"] and
       raw_keys["compile_topology_num_slices"] == -1 and not raw_keys["enable_single_controller"]
   ) or raw_keys["hardware"] == "gpu_multiprocess":
     max_logging.log("Attempting to initialize the jax distributed system...")
     jax.distributed.initialize()
     max_logging.log("Jax distributed system initialized!")
-  elif is_gpu_backend(raw_keys):
-    max_logging.log("Attempting to initialize the jax distributed system for GPU backend...")
-    initialize_jax_for_gpu()
-    max_logging.log("Jax distributed system initialized on GPU!")
   elif is_cpu_backend(raw_keys):
     max_logging.log("Attempting to initialize the jax distributed system for CPU backend...")
     initialize_jax_for_cpu()


### PR DESCRIPTION
Make sure we always call `initialize_jax_for_gpu()` to initialize JAX when running on GPUs. This change will allow us to make Orbax async checkpointing for MaxText on GPUs.