### PR TITLE
Explicitly specify tokenizer_path for pipeline tests

### DIFF
--- a/MaxText/tests/pipeline_parallelism_test.py
+++ b/MaxText/tests/pipeline_parallelism_test.py
@@ -206,7 +206,7 @@ class PipelineParallelismTest(unittest.TestCase):
           "ici_pipeline_parallelism=4",
           "num_layers_per_pipeline_stage=2",
           "num_pipeline_microbatches=8",
-
+          "tokenizer_path=../assets/tokenizer.llama2"          
     ])
 
   @pytest.mark.tpu
@@ -233,7 +233,7 @@ class PipelineParallelismTest(unittest.TestCase):
           "ici_pipeline_parallelism=4",
           "num_layers_per_pipeline_stage=8",
           "num_pipeline_microbatches=8",
-          
+          "tokenizer_path=../assets/tokenizer.llama2"          
     ])
 
 if __name__ == "__main__":


### PR DESCRIPTION
Not sure how these tests passed before (maybe caching), the tests are run from MaxText directory so need the path ../assets/llama2.tokenizer