### PR TITLE
Add maxengine_server configs to base.yml

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -330,6 +330,10 @@ reshape_q: False
 # Maxengine Metrics
 prometheus_port: 0
 
+# Maxengine server
+enable_jax_profiler: False
+jax_profiler_port: 9999
+
 # Checkpoint Structured logging
 enable_checkpoint_cloud_logger: False
 enable_checkpoint_standard_logger: False


### PR DESCRIPTION
PR #692 Added config parameteres to maxengine_server which are not present in base.yml, causing "Missing key in config" errors when using base.yml instead of inference_jetstream.yml
