### PR TITLE
Refactor permute and unpermute operations

### DIFF
--- a/MaxText/configs/models/mistral-7b.yml
+++ b/MaxText/configs/models/mistral-7b.yml
@@ -25,4 +25,5 @@ vocab_size: 32000
 enable_dropout: False
 logits_via_embedding: False
 normalization_layer_epsilon: 1.0e-5
+rope_max_timescale: 1_000_000
 decoder_block: "mistral"

--- a/MaxText/configs/models/mixtral-8x7b.yml
+++ b/MaxText/configs/models/mixtral-8x7b.yml
@@ -27,4 +27,5 @@ logits_via_embedding: False
 normalization_layer_epsilon: 1.0e-5
 num_experts: 8
 num_experts_per_tok: 2
+rope_max_timescale: 1_000_000
 decoder_block: "mistral"


### PR DESCRIPTION
# Description

* Refactor permute and unpermute operations to get a better perf.
* Update `rope_max_timescale` to match [HF config](https://screenshot.googleplex.com/XEAW6tP2iHcdhQy) from Mistral AI for both Mistral & Mixtral (thanks @ZhiyuLi-goog for bring it up).

# Test

Test locally: [link](https://paste.googleplex.com/5058156814401536)