### PR TITLE
Move Stage to second axis

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -128,7 +128,7 @@ jax_cache_dir: "~/jax_cache"
 hardware: 'tpu' # Supported hardware types are 'tpu', 'gpu', 'gpu_multiprocess' and 'cpu'
 
 # Parallelism
-mesh_axes: ['stage', 'data', 'fsdp', 'fsdp_transpose', 'sequence', 'tensor', 'autoregressive']
+mesh_axes: ['data', 'stage', 'fsdp', 'fsdp_transpose', 'sequence', 'tensor', 'autoregressive']
 logical_axis_rules: [
                       ['activation_batch', ['data', 'fsdp', 'fsdp_transpose',]],
                        # For pipeline parallelism the pre and post decoder layer tensors' batch dimension is sharded by stages.
@@ -163,7 +163,7 @@ logical_axis_rules: [
                       ['cache_sequence', []],
                     ]
 # Axes used for DCN must be earlier in this list than ICI, see (b/339009148) for details
-data_sharding: [['stage', 'data', 'fsdp', 'fsdp_transpose', 'sequence', 'tensor', 'autoregressive']]
+data_sharding: [['data', 'stage', 'fsdp', 'fsdp_transpose', 'sequence', 'tensor', 'autoregressive']]
 
 # One axis for each parallelism type may hold a placeholder (-1)
 # value to auto-shard based on available slices and devices.

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -337,8 +337,8 @@ def create_device_mesh(config, devices=None):
   multi_slice_env = num_slices > 1
 
   dcn_parallelism = [
-      config.dcn_pipeline_parallelism,
       config.dcn_data_parallelism,
+      config.dcn_pipeline_parallelism,
       config.dcn_fsdp_parallelism,
       config.dcn_fsdp_transpose_parallelism,
       config.dcn_sequence_parallelism,
@@ -346,8 +346,8 @@ def create_device_mesh(config, devices=None):
       config.dcn_autoregressive_parallelism,
   ]
   ici_parallelism = [
-      config.ici_pipeline_parallelism,
       config.ici_data_parallelism,
+      config.ici_pipeline_parallelism,
       config.ici_fsdp_parallelism,
       config.ici_fsdp_transpose_parallelism,
       config.ici_sequence_parallelism,


### PR DESCRIPTION
Move stage axis to second in list - orbax currently makes some assumptions that the data parallel axis is first for a few new features.

Tested via dcn [XPK logs](https://pantheon.corp.google.com/logs/query;query=resource.type%3D%22k8s_container%22%0Aresource.labels.project_id%3D%22tpu-prod-env-multipod%22%0Aresource.labels.location%3D%22us-central2%22%0Aresource.labels.cluster_name%3D%22v4-bodaborg%22%0Aresource.labels.namespace_name%3D%22default%22%0Alabels.k8s-pod%2Fjobset_sigs_k8s_io%2Fjobset-name%3D%22mattdavidow-after-clean-large-perf-a2222%22%20severity%3E%3DDEFAULT%0Aresource.labels.pod_name%3D%22mattdavidow-after-clean-large-perf-a2222-slice-job-0-0-bx6p4%22;storageScope=project;cursorTimestamp=2024-06-21T18:05:29.260588681Z;duration=PT1H?project=tpu-prod-env-multipod)

[XPK cmd](https://paste.googleplex.com/6069292168904704)

