### PR TITLE
Clean up MoE brute force implementation

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -91,8 +91,7 @@ head_dim: 128
 # mixture of experts (moe)
 num_experts: 1
 num_experts_per_tok: 1
-moe_matmul: False
-megablox: False
+megablox: True
 mlp_activations: ["silu", "linear"]
 dropout_rate: 0
 logits_via_embedding: False

--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -351,7 +351,7 @@ class MoeBlock(nn.Module):
     reshaped_intermediate = jnp.reshape(unsort_intermediate, (-1, self.num_experts_per_tok, self.config.emb_dim))
     with jax.named_scope("weight_sum"):
       output = jnp.einsum("BKE,BK -> BE", reshaped_intermediate, reshaped_weights)
-    return output.reshape(-1, self.config.max_target_length, self.config.emb_dim).astype(self.dtype)
+    return output.reshape(int(self.config.per_device_batch_size), -1, self.config.emb_dim).astype(self.dtype)
 
   def megablox(self, inputs, gate_logits, config, w0_kernel, w1_kernel, wo_kernel):
     # TODO(ranran): need to changes in JAX repo to enable optimized tile_size

--- a/MaxText/layers/mistral.py
+++ b/MaxText/layers/mistral.py
@@ -123,52 +123,19 @@ class MistralDecoderLayer(nn.Module):
     hidden_states = nn.with_logical_constraint(hidden_states, ("activation_batch", "activation_length", "activation_embed"))
 
     if cfg.num_experts > 1:
-      # TODO(ranran): remove for loop implementation after adding expert parallelism
-      if cfg.moe_matmul:
-        mlp_lnx = linears.MoeBlock(
-            config=cfg,
-            num_experts=cfg.num_experts,
-            num_experts_per_tok=cfg.num_experts_per_tok,
-            mesh=mesh,
-            kernel_init=initializers.nd_dense_init(1.0, 'fan_in', 'truncated_normal'),
-            kernel_axes=('embed', 'mlp'),
-            dtype=cfg.dtype,
-            weight_dtype=cfg.weight_dtype,
-        )(hidden_states)
-        mlp_lnx = nn.with_logical_constraint(
-            mlp_lnx, ('activation_batch', 'activation_length', 'activation_embed')
-        )
-      else:
-        max_logging.log("Running MoE for loop implementation.")
-        gate_logits = linears.DenseGeneral(
-            cfg.num_experts,
-            weight_dtype=cfg.weight_dtype,
-            dtype=cfg.dtype,
-            kernel_init=initializers.nd_dense_init(1.0, "fan_in", "truncated_normal"),
-            kernel_axes=("embed", "mlp"),
-            name="gate",
-            quant=self.quant,
-        )(hidden_states)
-        weights, selected_experts = jax.lax.top_k(gate_logits, cfg.num_experts_per_tok)
-        weights = jax.nn.softmax(weights.astype(jnp.float32), axis=-1)
-        mlp_lnx = jnp.zeros_like(hidden_states)
-        weights = weights.astype(cfg.dtype)
-        mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_length", "activation_embed"))
-
-        for k in range(cfg.num_experts):
-            weights_exp = jnp.sum(jnp.multiply(selected_experts == k, weights), axis=-1)
-            mlp_lnx_exp = linears.MlpBlock(
-                intermediate_dim=cfg.mlp_dim,
-                activations=cfg.mlp_activations,
-                intermediate_dropout_rate=cfg.dropout_rate,
-                dtype=cfg.dtype,
-                weight_dtype=cfg.weight_dtype,
-                name=f"mlp_{k}",
-                config=cfg,
-            )(hidden_states, deterministic=deterministic)
-            mlp_lnx_exp = nn.with_logical_constraint(mlp_lnx_exp, ("activation_batch", "activation_length", "activation_embed"))
-            mlp_lnx_exp = weights_exp[:, :, None] * mlp_lnx_exp
-            mlp_lnx += mlp_lnx_exp
+      mlp_lnx = linears.MoeBlock(
+          config=cfg,
+          num_experts=cfg.num_experts,
+          num_experts_per_tok=cfg.num_experts_per_tok,
+          mesh=mesh,
+          kernel_init=initializers.nd_dense_init(1.0, 'fan_in', 'truncated_normal'),
+          kernel_axes=('embed', 'mlp'),
+          dtype=cfg.dtype,
+          weight_dtype=cfg.weight_dtype,
+      )(hidden_states)
+      mlp_lnx = nn.with_logical_constraint(
+          mlp_lnx, ('activation_batch', 'activation_length', 'activation_embed')
+      )
     else:
       mlp_lnx = linears.MlpBlock(
           intermediate_dim=cfg.mlp_dim,

--- a/MaxText/llama_or_mistral_ckpt.py
+++ b/MaxText/llama_or_mistral_ckpt.py
@@ -104,7 +104,7 @@ MODEL_PARAMS_DICT = {
 SIMULATED_CPU_DEVICES_COUNT = 16
 
 
-def convert(base_model_path, maxtext_model_path, model_size, moe_matmul):
+def convert(base_model_path, maxtext_model_path, model_size):
   """
   Function to convert the checkpoint at base_model_path into Orbax checkpoint
   for MaxText and save at maxtext_model_path
@@ -113,7 +113,6 @@ def convert(base_model_path, maxtext_model_path, model_size, moe_matmul):
   base_model_path: checkpoint path
   maxtext_model_path: Path to save the MaxText checkpoint to
   model_size: llama2-7b to 70b, mistral-7b, or mixtral-8x7b
-  moe_matmul: Indicate if run MoE block through matmul, otherwise through for loop
   """
   """Convert model to maxtext."""
   model_params = MODEL_PARAMS_DICT[model_size]
@@ -135,7 +134,7 @@ def convert(base_model_path, maxtext_model_path, model_size, moe_matmul):
   pytorch_vars = [pytorch_vars[i] for i in sorted(list(pytorch_vars.keys()))]
 
   if num_experts:
-    layer_key = "MoeBlock_0" if moe_matmul else "gate"
+    layer_key = "MoeBlock_0"
   else:
     layer_key = "mlp"
   jax_weights = {
@@ -172,10 +171,7 @@ def convert(base_model_path, maxtext_model_path, model_size, moe_matmul):
     layer_weight["gate"] = {"kernel": []}
 
     for k in range(num_experts):
-      if moe_matmul:
-        jax_weights["decoder"]["layers"]["MoeBlock_0"]["gate"] = {}
-      else:
-        jax_weights["decoder"]["layers"][f"mlp_{k}"] = {}
+      jax_weights["decoder"]["layers"]["MoeBlock_0"]["gate"] = {}
       layer_weight[f"mlp_{k}"] = {
           "wi_0": {"kernel": []},
           "wi_1": {"kernel": []},
@@ -308,35 +304,23 @@ def convert(base_model_path, maxtext_model_path, model_size, moe_matmul):
   else:
     layer_weight["gate"]["kernel"] = np.array(layer_weight["gate"]["kernel"])
     layer_weight["gate"]["kernel"] = np.transpose(layer_weight["gate"]["kernel"], axes=(1, 0, 2))
-    if moe_matmul:
-      jax_weights["decoder"]["layers"]["MoeBlock_0"]["gate"]["kernel"] = layer_weight["gate"]["kernel"]
-      all_wi_0 = []
-      all_wi_1 = []
-      all_wo = []
-    else:
-      jax_weights["decoder"]["layers"]["gate"] = layer_weight["gate"]
+    jax_weights["decoder"]["layers"]["MoeBlock_0"]["gate"]["kernel"] = layer_weight["gate"]["kernel"]
+    all_wi_0 = []
+    all_wi_1 = []
+    all_wo = []
 
     for k in range(num_experts):
       layer_weight[f"mlp_{k}"]["wi_0"]["kernel"] = np.array(layer_weight[f"mlp_{k}"]["wi_0"]["kernel"])
       layer_weight[f"mlp_{k}"]["wi_1"]["kernel"] = np.array(layer_weight[f"mlp_{k}"]["wi_1"]["kernel"])
       layer_weight[f"mlp_{k}"]["wo"]["kernel"] = np.array(layer_weight[f"mlp_{k}"]["wo"]["kernel"])
 
-      if moe_matmul:
-        all_wi_0.append(layer_weight[f"mlp_{k}"]["wi_0"]["kernel"])
-        all_wi_1.append(layer_weight[f"mlp_{k}"]["wi_1"]["kernel"])
-        all_wo.append(layer_weight[f"mlp_{k}"]["wo"]["kernel"])
-      else:
-        # swap the layer index
-        layer_weight[f"mlp_{k}"]["wi_0"]["kernel"] = np.transpose(layer_weight[f"mlp_{k}"]["wi_0"]["kernel"], axes=(1, 0, 2))
-        layer_weight[f"mlp_{k}"]["wi_1"]["kernel"] = np.transpose(layer_weight[f"mlp_{k}"]["wi_1"]["kernel"], axes=(1, 0, 2))
-        layer_weight[f"mlp_{k}"]["wo"]["kernel"] = np.transpose(layer_weight[f"mlp_{k}"]["wo"]["kernel"], axes=(1, 0, 2))
+      all_wi_0.append(layer_weight[f"mlp_{k}"]["wi_0"]["kernel"])
+      all_wi_1.append(layer_weight[f"mlp_{k}"]["wi_1"]["kernel"])
+      all_wo.append(layer_weight[f"mlp_{k}"]["wo"]["kernel"])
 
-        jax_weights["decoder"]["layers"][f"mlp_{k}"] = layer_weight[f"mlp_{k}"]
-
-    if moe_matmul:
-      jax_weights["decoder"]["layers"]["MoeBlock_0"]["wi_0"] = np.array(all_wi_0)
-      jax_weights["decoder"]["layers"]["MoeBlock_0"]["wi_1"] = np.array(all_wi_1)
-      jax_weights["decoder"]["layers"]["MoeBlock_0"]["wo"] = np.array(all_wo)
+    jax_weights["decoder"]["layers"]["MoeBlock_0"]["wi_0"] = np.array(all_wi_0)
+    jax_weights["decoder"]["layers"]["MoeBlock_0"]["wi_1"] = np.array(all_wi_1)
+    jax_weights["decoder"]["layers"]["MoeBlock_0"]["wo"] = np.array(all_wo)
 
   mesh = jax.sharding.Mesh(jax.devices(), "checkpoint_sharding_axis")
   s1 = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec("checkpoint_sharding_axis"))  # shards first axis
@@ -385,7 +369,6 @@ if __name__ == "__main__":
   parser.add_argument("--base-model-path", type=str, required=True)
   parser.add_argument("--maxtext-model-path", type=str, required=True)
   parser.add_argument("--model-size", type=str, required=True)
-  parser.add_argument("--moe-matmul", type=bool, required=False, default=False)
 
   args = parser.parse_args()
 
@@ -394,4 +377,4 @@ if __name__ == "__main__":
 
   os.environ["XLA_FLAGS"] = f"--xla_force_host_platform_device_count={SIMULATED_CPU_DEVICES_COUNT}"
 
-  convert(args.base_model_path, args.maxtext_model_path, args.model_size, args.moe_matmul)
+  convert(args.base_model_path, args.maxtext_model_path, args.model_size)

--- a/end_to_end/tpu/mixtral/8x7b/1_test_mixtral.sh
+++ b/end_to_end/tpu/mixtral/8x7b/1_test_mixtral.sh
@@ -22,13 +22,9 @@ fi
 pip3 install torch
 gcloud storage cp -r gs://maxtext-external/mixtral-8x7B-v0.1-Instruct /tmp
 
-# Convert it to MaxText(orbax) format - scanned ckpt (for loop implementation)
+# Convert it to MaxText(orbax) format - scanned ckpt
 JAX_PLATFORMS=cpu python3 MaxText/llama_or_mistral_ckpt.py --base-model-path=/tmp/mixtral-8x7B-v0.1-Instruct --model-size=mixtral-8x7b --maxtext-model-path=${BASE_OUTPUT_PATH}${MODEL_VARIATION}/scanned_ckpt/
 echo "Wrote MaxText compatible scanned checkpoint to ${BASE_OUTPUT_PATH}${MODEL_VARIATION}/scanned_ckpt"
-
-# Convert it to MaxText(orbax) format - scanned ckpt (matmul implementation)
-JAX_PLATFORMS=cpu python3 MaxText/llama_or_mistral_ckpt.py --base-model-path=/tmp/mixtral-8x7B-v0.1-Instruct --model-size=mixtral-8x7b --maxtext-model-path=${BASE_OUTPUT_PATH}${MODEL_VARIATION}/matmul_scanned_ckpt/ --moe-matmul=True
-echo "Wrote MaxText compatible scanned checkpoint to ${BASE_OUTPUT_PATH}${MODEL_VARIATION}/matmul_scanned_ckpt"
 
 # Generate unscanned ckpt for efficient decoding test
 export SCANNED_CHECKPOINT=${BASE_OUTPUT_PATH}${MODEL_VARIATION}/scanned_ckpt/0/items

--- a/end_to_end/tpu/mixtral/8x7b/2_test_mixtral.sh
+++ b/end_to_end/tpu/mixtral/8x7b/2_test_mixtral.sh
@@ -23,24 +23,21 @@ export DATASET_PATH=gs://maxtext-dataset
 
 # `SCANNED_CHECKPOINT` refers to the checkpoint that used for both `train.py` and `decode.py` 
 export SCANNED_CHECKPOINT=${BASE_OUTPUT_PATH}${MODEL_VARIATION}/scanned_ckpt/0/items
-export MATMUL_SCANNED_CHECKPOINT=${BASE_OUTPUT_PATH}${MODEL_VARIATION}/matmul_scanned_ckpt/0/items
 
-# Run decoding with converted ckpt
-python3 MaxText/decode.py MaxText/configs/base.yml load_parameters_path=${SCANNED_CHECKPOINT} run_name=scanned_decoding per_device_batch_size=1 model_name=mixtral-8x7b async_checkpointing=false tokenizer_path=gs://maxtext-external/mixtral-8x7B-v0.1-Instruct/tokenizer.mistral ici_tensor_parallelism=4 ici_fsdp_parallelism=16 max_prefill_predict_length=11 max_target_length=24 prompt="[INST] I love to [/INST]" autoregressive_decode_assert="That's great to hear! I love to learn new things" attention=dot_product
-
-# Test whether the forward pass logits match the golden logits - for loop implementation
-python3 MaxText/tests/forward_pass_logit_checker.py MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} load_parameters_path=${SCANNED_CHECKPOINT} run_name=forward_pass_test per_device_batch_size=1 model_name=mixtral-8x7b tokenizer_path=gs://maxtext-external/mixtral-8x7B-v0.1-Instruct/tokenizer.mistral ici_tensor_parallelism=4 ici_fsdp_parallelism=16 max_prefill_predict_length=11 max_target_length=11 dataset_type=synthetic dtype=float32 --atol=1 --rtol=0.5 --token_size=4
+# Run decoding with converted ckpt - matmul implementation
+# TODO(ranran): add decoding test for megablox implementation
+python3 MaxText/decode.py MaxText/configs/base.yml load_parameters_path=${SCANNED_CHECKPOINT} run_name=scanned_decoding per_device_batch_size=1 model_name=mixtral-8x7b async_checkpointing=false tokenizer_path=assets/tokenizer.mistral ici_tensor_parallelism=4 ici_fsdp_parallelism=16 max_prefill_predict_length=11 max_target_length=24 prompt="[INST] I love to [/INST]" megablox=False
 
 # Test whether the forward pass logits match the golden logits - matmul implementation
-python3 MaxText/tests/forward_pass_logit_checker.py MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} load_parameters_path=${MATMUL_SCANNED_CHECKPOINT} run_name=matmul_forward_pass_test per_device_batch_size=1 model_name=mixtral-8x7b tokenizer_path=gs://maxtext-external/mixtral-8x7B-v0.1-Instruct/tokenizer.mistral ici_tensor_parallelism=4 ici_fsdp_parallelism=16 max_prefill_predict_length=11 max_target_length=11 dataset_type=synthetic dtype=float32 moe_matmul=True --atol=3 --rtol=1 --token_size=4
+python3 MaxText/tests/forward_pass_logit_checker.py MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} load_parameters_path=${SCANNED_CHECKPOINT} run_name=matmul_forward_pass_test per_device_batch_size=8 model_name=mixtral-8x7b tokenizer_path=assets/tokenizer.mistral ici_tensor_parallelism=4 ici_fsdp_parallelism=16 max_prefill_predict_length=11 max_target_length=11 dataset_type=synthetic dtype=float32 megablox=False --atol=3 --rtol=1 --token_size=4
 
 # Test whether the forward pass logits match the golden logits - megablox implementation
-python3 MaxText/tests/forward_pass_logit_checker.py MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} load_parameters_path=${MATMUL_SCANNED_CHECKPOINT} run_name=megablox_forward_pass_test per_device_batch_size=1 model_name=mixtral-8x7b tokenizer_path=gs://maxtext-external/mixtral-8x7B-v0.1-Instruct/tokenizer.mistral ici_tensor_parallelism=4 ici_fsdp_parallelism=16 max_prefill_predict_length=11 max_target_length=11 dataset_type=synthetic dtype=float32 moe_matmul=True megablox=True --atol=3 --rtol=1 --token_size=4
+python3 MaxText/tests/forward_pass_logit_checker.py MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} load_parameters_path=${SCANNED_CHECKPOINT} run_name=megablox_forward_pass_test per_device_batch_size=8 model_name=mixtral-8x7b tokenizer_path=assets/tokenizer.mistral ici_fsdp_parallelism=64 max_prefill_predict_length=11 max_target_length=11 dataset_type=synthetic dtype=bfloat16 weight_dtype=bfloat16 --atol=4 --rtol=1 --token_size=4
 
-# Run fine-tuning
-python3 MaxText/train.py MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} dataset_path=${DATASET_PATH} load_parameters_path=${SCANNED_CHECKPOINT} run_name=fine_tuning per_device_batch_size=1 model_name=mixtral-8x7b ici_tensor_parallelism=4 ici_fsdp_parallelism=16 steps=10 max_target_length=1024 async_checkpointing=false tokenizer_path=gs://maxtext-external/mixtral-8x7B-v0.1-Instruct/tokenizer.mistral checkpoint_period=5
+# Run fine-tuning - megablox implementation
+python3 MaxText/train.py MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} dataset_path=${DATASET_PATH} load_parameters_path=${SCANNED_CHECKPOINT} run_name=fine_tuning per_device_batch_size=8 model_name=mixtral-8x7b ici_fsdp_parallelism=64 steps=10 max_target_length=1024 async_checkpointing=false tokenizer_path=assets/tokenizer.mistral checkpoint_period=5 attention=flash dtype=bfloat16 weight_dtype=bfloat16
 
-# Run pre-training without load_parameters_path
-python3 MaxText/train.py MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} dataset_path=${DATASET_PATH} run_name=pre_training per_device_batch_size=1 enable_checkpointing=false model_name=mixtral-8x7b ici_tensor_parallelism=4 ici_fsdp_parallelism=16 steps=5 max_target_length=1024 async_checkpointing=false tokenizer_path=gs://maxtext-external/mixtral-8x7B-v0.1-Instruct/tokenizer.mistral
+# Run pre-training without load_parameters_path - megablox implementation
+python3 MaxText/train.py MaxText/configs/base.yml base_output_directory=${BASE_OUTPUT_PATH} dataset_path=${DATASET_PATH} run_name=pre_training per_device_batch_size=8 enable_checkpointing=false model_name=mixtral-8x7b ici_fsdp_parallelism=64 steps=5 max_target_length=1024 async_checkpointing=false tokenizer_path=assets/tokenizer.mistral attention=flash dtype=bfloat16 weight_dtype=bfloat16
 
 # TODO(ranran): Run decoding with unscanned ckpt


### PR DESCRIPTION
# Description:

Clean up MoE brute force implementation, so that we have 2 strategies:
1) MoE dropless
2) MoE dropping (with expert parallelism in the future)

# Test

Test script 1: [link](https://pantheon.corp.google.com/kubernetes/service/us-central1/m1-megamem-96-shared/default/clean-loop-1-4/logs?e=13803378&mods=allow_workbench_image_override&project=tpu-prod-env-multipod)
Test script 2: [link](https://pantheon.corp.google.com/kubernetes/service/us-central2/v4-bodaborg/default/clean-loop-2-11/logs?e=13803378&mods=allow_workbench_image_override&project=tpu-prod-env-multipod)