### PR TITLE
Integrate goodput monitor

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -323,6 +323,8 @@ target_eval_loss: 0.  # early stop once reaching target eval_loss
 
 # Goodput parameters
 enable_goodput_recording: False
+monitor_goodput: False
+goodput_upload_interval_seconds: 60
 
 # Vertex AI Tensorboard Configurations - https://github.com/google/maxtext/tree/main/getting_started/Use_Vertex_AI_Tensorboard.md
 # Set to True for GCE, False if running via XPK


### PR DESCRIPTION
This changes adds the following:

Allows creating on a monitor object that spins up a secondary "monitor & upload" thread to query Goodput of the job using the ml-goodput-measurement pip package and and write a scalar metric to TB every interval period.
Tested:

 - [x] Example run on v4-8 w/ ~180 steps [here](https://screenshot.googleplex.com/82o5gNmW6ihb5Eq)