### PR TITLE
Fix validation error for other models

### DIFF
--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -396,8 +396,9 @@ def validate_and_update_keys(raw_keys, model_keys, config_name: str):
   """Validate and update model specific config keys"""
   max_logging.log("Updating following parameters in config\n")
 
-  # Currently, Megablox only supports data parallelism
-  validate_megablox_parallelism(raw_keys)
+  if raw_keys["num_experts"] > 1:
+    # Currently, Megablox only supports data parallelism
+    validate_megablox_parallelism(raw_keys)
 
   for k in model_keys:
     max_logging.log(f"{k}: {model_keys[k]}")


### PR DESCRIPTION
# Description

Nightly gpt3 175b tests met megablox parallelism validatoin error `ValueError: Currently we only support Megablox with data parallelism` ([here](https://screenshot.googleplex.com/9ePHtqEPxwRtdsR)). This is because we set megablox flag as True when cleaning up brute force implementation ([here](https://github.com/google/maxtext/blob/89edace7ecf346381857c6d5c3ae0a432f02653e/MaxText/configs/base.yml#L94)).

The solution is to turn on this validation only for MoE model.

# Test

Running train_compile.py script (non-MoE): [link](https://paste.googleplex.com/6188773140594688)