### PR TITLE
Enable quantization for MoE Gating

### DIFF
--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -278,6 +278,7 @@ class MoeBlock(nn.Module):
     kernel_axes: Tuple with axes to apply kernel function.
     weight_dtype: Type for the weights.
     dtype: Type for the dense layer.
+    quant: Optional quantization config, no quantization if None.
   """
 
   config: Config
@@ -288,6 +289,7 @@ class MoeBlock(nn.Module):
   kernel_axes: Tuple[str, ...]
   weight_dtype: DType = jnp.float32
   dtype: DType = jnp.float32
+  quant: Optional[Quant] = None
 
   def generate_kernels(self, num_experts, emb_dim, mlp_dim):
 
@@ -411,6 +413,7 @@ class MoeBlock(nn.Module):
             self.num_experts,
             dtype=self.dtype,
             weight_dtype=self.weight_dtype,
+            quant=self.quant,
             kernel_init=self.kernel_init,
             kernel_axes=self.kernel_axes,
             name="gate")(inputs)

--- a/MaxText/layers/mistral.py
+++ b/MaxText/layers/mistral.py
@@ -132,6 +132,7 @@ class MistralDecoderLayer(nn.Module):
           kernel_axes=('embed', 'mlp'),
           dtype=cfg.dtype,
           weight_dtype=cfg.weight_dtype,
+          quant=self.quant,
       )(hidden_states)
       mlp_lnx = nn.with_logical_constraint(
           mlp_lnx, ('activation_batch', 'activation_length', 'activation_embed')
@@ -145,6 +146,7 @@ class MistralDecoderLayer(nn.Module):
           weight_dtype=cfg.weight_dtype,
           name="mlp",
           config=cfg,
+          quant=self.quant,
       )(hidden_states, deterministic=deterministic)
       mlp_lnx = nn.with_logical_constraint(mlp_lnx, ("activation_batch", "activation_length", "activation_embed"))
 


### PR DESCRIPTION
# Description
* Enable quantization for MoE Gating (will work on kernel quantization as next step)
* Observed perf regression when quantizing einsum(), so not include in this PR. Need to dive deep for matmul implementation later.

# Test
Adding `quantization=int8` flag:
* Megablox without kernel quantization ([test](https://pantheon.corp.google.com/kubernetes/service/us-east5/v5p-128-bodaborg-us-east5-a/default/ran-mega-quant2/logs?e=13803378&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev), mixed precision in [xprof](https://screenshot.googleplex.com/8ZMi3e63EqHYGBN) in gating)