### PR TITLE
Cast type for inputs before kernel call

### DIFF
--- a/MaxText/layers/linears.py
+++ b/MaxText/layers/linears.py
@@ -364,7 +364,7 @@ class MoeBlock(nn.Module):
         inputs = jax.lax.pad(inputs.astype(jnp.float32), 0.0, [(0, pad_length, 0), (0,0,0)])
 
       inputs = inputs.astype(self.dtype)
-      kernel = kernel.astype(self.weight_dtype)
+      kernel = kernel.astype(self.dtype)
       output = mblx.gmm(lhs=inputs,
                         rhs=kernel,
                         group_sizes=group_sizes,


### PR DESCRIPTION
# Description

Cast kernel type to dtype so that we could use float32 to initialize weights.

# Test

After change with default weight type float32: Test - [link](https://pantheon.corp.google.com/kubernetes/service/us-east5/v5p-128-bodaborg-us-east5-a/default/ran-test-type1/logs?e=13803378&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev) - 246.002
Before change with weight type bf16: Test - [link](https://pantheon.corp.google.com/kubernetes/service/us-east5/v5p-128-bodaborg-us-east5-a/default/ran-test-type3/logs?e=13803378&mods=allow_workbench_image_override&project=cloud-tpu-multipod-dev) - 245.814