### PR TITLE
Adding Tokens/s/device to the log.

### DIFF
--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -92,6 +92,9 @@ def load_compiled(config, partial_train, state):
   p_train_step = deserialize_and_load(serialized_compiled, in_tree, out_tree)
   return p_train_step
 
+def calculate_tokens_training_per_device(config):
+  """Calculate training Tokens per device"""
+  return config.max_target_length * config.per_device_batch_size
 
 def calculate_tflops_training_per_device(config, log=True):
   """Calculate training TFLOP"""


### PR DESCRIPTION
Adding Tokens/s/device to the print log for each step.

Example:
`completed step: 9, seconds: 1.341, TFLOP/s/device: 257.929, Tokens/s/device: 36653.244, loss: 0.000`