### PR TITLE
Fix update logical axis rules

### DIFF
--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -404,7 +404,7 @@ def create_new_logical_axis_rules(old_logical_axis_rules, new_logical_axis_rules
       continue
     replacements.append((logical_axis, mesh_axes))
     new_logical_axis.add(logical_axis)
-  old_logical_rules_filtered = [(old_logical_axis, old_mesh_axes) for old_logical_axis, old_mesh_axes
+  old_logical_rules_filtered = [(old_logical_axis, _lists_to_tuples(old_mesh_axes)) for old_logical_axis, old_mesh_axes
                                   in old_logical_axis_rules if old_logical_axis not in new_logical_axis]
   return old_logical_rules_filtered + replacements
 

--- a/MaxText/tests/pyconfig_test.py
+++ b/MaxText/tests/pyconfig_test.py
@@ -82,7 +82,7 @@ class PyconfigTest(unittest.TestCase):
       'megablox': None,
       'foo': ['bar', 'baz'],
       'logical_axis_rules': [
-        ('activation', ['data', 'fsdp']),
+        ('activation', ('data', 'fsdp')),
         ('norm', 'fsdp')
       ]
     })


### PR DESCRIPTION
Thank you @gobbleturk for pair programming with me. 

Tested using `python3 MaxText/generate_param_only_checkpoint.py MaxText/configs/base.yml base_output_directory=gs://runner-maxtext-logs load_parameters_path=gs://maxtext-llama/test/2024-07-13-04-07/decode-ckpt-maxtext/0/items run_name=direct_generate_param_only_checkpoint_$(date +%Y-%m-%d-%H-%M) model_name=llama2-7b force_unroll=true`