### PR TITLE
Lower number of steps for configs

### DIFF
--- a/MaxText/configs/v5e/128b.sh
+++ b/MaxText/configs/v5e/128b.sh
@@ -42,7 +42,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
-    steps=30 per_device_batch_size=1 enable_checkpointing=false\
+    steps=15 per_device_batch_size=1 enable_checkpointing=false\
     remat_policy=qkv_proj_offloaded global_parameter_scale=128\
     ici_fsdp_parallelism=16 ici_tensor_parallelism=16\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\

--- a/MaxText/configs/v5e/16b.sh
+++ b/MaxText/configs/v5e/16b.sh
@@ -41,7 +41,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
-    steps=30 per_device_batch_size=6 enable_checkpointing=false\
+    steps=15 per_device_batch_size=6 enable_checkpointing=false\
     remat_policy=full global_parameter_scale=16\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/configs/v5e/32b.sh
+++ b/MaxText/configs/v5e/32b.sh
@@ -41,7 +41,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
-    steps=30 per_device_batch_size=4 enable_checkpointing=false\
+    steps=15 per_device_batch_size=4 enable_checkpointing=false\
     remat_policy=full global_parameter_scale=32\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/configs/v5e/64b.sh
+++ b/MaxText/configs/v5e/64b.sh
@@ -41,7 +41,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
-    steps=30 per_device_batch_size=2 enable_checkpointing=false\
+    steps=15 per_device_batch_size=2 enable_checkpointing=false\
     remat_policy=full global_parameter_scale=64\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\
     dataset_path=$DATASET_PATH use_iota_embed=true reuse_example_batch=1\

--- a/MaxText/configs/v5e/gpt3_175b.sh
+++ b/MaxText/configs/v5e/gpt3_175b.sh
@@ -41,7 +41,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true --xla_tpu_spmd_rng_bit_generator_unsafe=true"
 
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml model_name=gpt3-175b\
-  steps=30 per_device_batch_size=0.5 enable_checkpointing=false\
+  steps=15 per_device_batch_size=0.5 enable_checkpointing=false\
   remat_policy=full ici_fsdp_parallelism=-1 ici_tensor_parallelism=16\
   max_target_length=2048 base_output_directory=$OUTPUT_PATH\
   reuse_example_batch=1 dataset_type=synthetic gcs_metrics=true\

--- a/MaxText/configs/v5e/llama2_13b.sh
+++ b/MaxText/configs/v5e/llama2_13b.sh
@@ -43,4 +43,4 @@ export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xl
 python MaxText/$EXECUTABLE MaxText/configs/base.yml model_name=llama2-13b\
   base_output_directory=$OUTPUT_PATH dataset_path=${DATASET_PATH}\
   tokenizer_path=assets/tokenizer.llama2 per_device_batch_size=8 remat_policy=qkv_proj_offloaded\
-  steps=30 enable_checkpointing=false use_iota_embed=true
+  steps=15 enable_checkpointing=false use_iota_embed=true

--- a/MaxText/configs/v5e/llama2_70b.sh
+++ b/MaxText/configs/v5e/llama2_70b.sh
@@ -43,4 +43,4 @@ export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xl
 python MaxText/$EXECUTABLE MaxText/configs/base.yml model_name=llama2-70b\
   base_output_directory=$OUTPUT_PATH dataset_path=${DATASET_PATH}\
   tokenizer_path=assets/tokenizer.llama2 per_device_batch_size=2 remat_policy=qkv_proj_offloaded\
-  steps=30 enable_checkpointing=false use_iota_embed=true
+  steps=15 enable_checkpointing=false use_iota_embed=true

--- a/MaxText/configs/v5e/llama2_7b.sh
+++ b/MaxText/configs/v5e/llama2_7b.sh
@@ -43,4 +43,4 @@ export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xl
 python MaxText/$EXECUTABLE MaxText/configs/base.yml model_name=llama2-7b\
   base_output_directory=$OUTPUT_PATH dataset_path=${DATASET_PATH}\
   tokenizer_path=assets/tokenizer.llama2 per_device_batch_size=4 remat_policy=save_qkv_proj\
-  steps=30 enable_checkpointing=false use_iota_embed=true
+  steps=15 enable_checkpointing=false use_iota_embed=true

--- a/MaxText/configs/v5p/1024b.sh
+++ b/MaxText/configs/v5p/1024b.sh
@@ -41,7 +41,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
-    steps=20 per_device_batch_size=2 enable_checkpointing=false\
+    steps=15 per_device_batch_size=2 enable_checkpointing=false\
     remat_policy=full global_parameter_scale=1024\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=16\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\

--- a/MaxText/configs/v5p/128b.sh
+++ b/MaxText/configs/v5p/128b.sh
@@ -41,7 +41,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
-    steps=30 per_device_batch_size=1 enable_checkpointing=false\
+    steps=15 per_device_batch_size=1 enable_checkpointing=false\
     remat_policy=minimal global_parameter_scale=128\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=8\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\

--- a/MaxText/configs/v5p/256b.sh
+++ b/MaxText/configs/v5p/256b.sh
@@ -41,7 +41,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
-    steps=20 per_device_batch_size=1 enable_checkpointing=false\
+    steps=15 per_device_batch_size=1 enable_checkpointing=false\
     remat_policy=minimal global_parameter_scale=256\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=8\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\

--- a/MaxText/configs/v5p/32b.sh
+++ b/MaxText/configs/v5p/32b.sh
@@ -41,7 +41,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
-    steps=30 per_device_batch_size=6 enable_checkpointing=false\
+    steps=15 per_device_batch_size=6 enable_checkpointing=false\
     remat_policy=minimal global_parameter_scale=32\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=4\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\

--- a/MaxText/configs/v5p/512b.sh
+++ b/MaxText/configs/v5p/512b.sh
@@ -41,7 +41,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
-    steps=20 per_device_batch_size=2 enable_checkpointing=false\
+    steps=15 per_device_batch_size=2 enable_checkpointing=false\
     remat_policy=full global_parameter_scale=512\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=8\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\

--- a/MaxText/configs/v5p/64b.sh
+++ b/MaxText/configs/v5p/64b.sh
@@ -41,7 +41,7 @@ bash preflight.sh PLATFORM=$PLATFORM
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"
 python3 MaxText/$EXECUTABLE MaxText/configs/base.yml\
-    steps=30 per_device_batch_size=3 enable_checkpointing=false\
+    steps=15 per_device_batch_size=3 enable_checkpointing=false\
     remat_policy=minimal global_parameter_scale=64\
     ici_fsdp_parallelism=-1 ici_tensor_parallelism=4\
     max_target_length=2048 base_output_directory=$OUTPUT_PATH\


### PR DESCRIPTION
Lowering number of steps to run in configs. Step time usually stabilizes after first few steps. This is so that the nightly perf tests run faster and reduces timeouts. 