### PR TITLE
Add tp support for MoE

### DIFF
--- a/MaxText/common_types.py
+++ b/MaxText/common_types.py
@@ -35,6 +35,7 @@ AxisIdxes = tuple[int, ...]
 
 BATCH = "activation_batch"
 LENGTH = "activation_length"
+EMBED = "activation_embed"
 HEAD = "activation_heads"
 KV_BATCH = "activation_kv_batch"
 KV_HEAD = "activation_kv_heads"


### PR DESCRIPTION
# Description

Adding Tensor Parallelism support for MoE.

# Test

* local test with same inputs MoE block that matches output with existing implementation - [test](https://paste.googleplex.com/6076613743869952)
* end-to-end train.py [test](https://paste.googleplex.com/5919901795745792)
