### PR TITLE
Add support for proxy backend when running maxengine_server

### DIFF
--- a/MaxText/maxengine_server.py
+++ b/MaxText/maxengine_server.py
@@ -19,6 +19,8 @@ import os
 import sys
 import pyconfig
 
+# pylint: disable-next=unused-import
+import register_jax_proxy_backend
 import maxengine_config
 from jetstream.core import server_lib, config_lib
 


### PR DESCRIPTION
This is needed in order to use maxengine with multi host models