### PR TITLE
Add enable_model_warmup flag for AOT compilation at model server start

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -360,6 +360,8 @@ inference_microbenchmark_stages: "prefill,generate"
 inference_microbenchmark_loop_iters: 10
 inference_microbenchmark_log_file_path: ""
 inference_metadata_file: "" # path to a json file
+enable_model_warmup: False
+
 
 # KV Cache layout control
 # Logical layout: 0,1,2,3 ; CACHE_BATCH, CACHE_SEQUENCE, CACHE_HEADS, CACHE_KV

--- a/MaxText/configs/inference_jetstream.yml
+++ b/MaxText/configs/inference_jetstream.yml
@@ -2,3 +2,5 @@ base_config: "base.yml"
 
 enable_jax_profiler: False
 jax_profiler_port: 9999
+
+enable_model_warmup: False

--- a/MaxText/maxengine_server.py
+++ b/MaxText/maxengine_server.py
@@ -56,7 +56,8 @@ def main(config):
       devices=devices,
       metrics_server_config=metrics_server_config,
       enable_jax_profiler=config.enable_jax_profiler if config.enable_jax_profiler else False,
-      jax_profiler_port=config.jax_profiler_port if config.jax_profiler_port else 9999
+      jax_profiler_port=config.jax_profiler_port if config.jax_profiler_port else 9999,
+      enable_model_warmup=config.enable_model_warmup if config.enable_model_warmup else False
   )
   jetstream_server.wait_for_termination()
 


### PR DESCRIPTION
Add the `enable_model_warmup` flag at model server start
Associated PR: https://github.com/google/JetStream/pull/92

```
 - model_name=gemma-7b
  - tokenizer_path=assets/tokenizer.gemma
  - per_device_batch_size=1
  - max_prefill_predict_length=1024
  - max_target_length=2048
  - async_checkpointing=false
  - ici_fsdp_parallelism=1
  - ici_autoregressive_parallelism=-1
  - ici_tensor_parallelism=1
  - scan_layers=false
  - weight_dtype=bfloat16
  - load_parameters_path=<ckpt_path>
  - enable_model_warmup=true

curl --request POST --header "Content-type: application/json" -s localhost:8000/generate --data '{
    "prompt": "What are the top 5 programming languages",
    "max_tokens": 200
}'
{
    "response": " for data science in 2023?\n\n1. Python\n2. R\n3. SQL\n4. Java\n5. Scala\n\n**Note:** The order is based on popularity and demand in the data science industry in 2023."
}
```

PR is dupe of https://github.com/google/maxtext/pull/764, which failed checks because it was a PR from a forked repo