### PR TITLE
Refactoring Maxtext-JAX-Stable-Stack Build Process

### DIFF
--- a/.github/workflows/UploadDockerImages.yml
+++ b/.github/workflows/UploadDockerImages.yml
@@ -39,7 +39,7 @@ jobs:
         bash .github/workflows/build_and_upload_images.sh CLOUD_IMAGE_NAME=maxtext_jax_nightly MODE=nightly DEVICE=tpu PROJECT=tpu-prod-env-multipod LOCAL_IMAGE_NAME=maxtext_jax_nightly
     - name: build jax stable stack image
       run : |
-        bash docker_maxtext_jax_stable_stack_image_upload.sh PROJECT_ID=tpu-prod-env-multipod BASEIMAGE=us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/tpu:jax0.4.30-rev1 CLOUD_IMAGE_NAME=maxtext-jax-stable-stack IMAGE_TAG=jax0.4.30-rev1 MAXTEXT_REQUIREMENTS_FILE=requirements_with_jax_stable_stack.txt
+        bash docker_maxtext_jax_stable_stack_image_upload.sh PROJECT_ID=tpu-prod-env-multipod BASEIMAGE=us-docker.pkg.dev/tpu-prod-env-multipod/jax-stable-stack/tpu:jax0.4.30-rev1 CLOUD_IMAGE_NAME=maxtext-jax-stable-stack IMAGE_TAG=jax0.4.30-rev1 MAXTEXT_REQUIREMENTS_FILE=requirements_with_jax_stable_stack.txt DELETE_LOCAL_IMAGE=true
   gpu:
     strategy:
       fail-fast: false

--- a/docker_maxtext_jax_stable_stack_image_upload.sh
+++ b/docker_maxtext_jax_stable_stack_image_upload.sh
@@ -59,6 +59,9 @@ if [[ ! -v MAXTEXT_REQUIREMENTS_FILE ]]; then
   exit 1
 fi
 
+# Default: Don't delete local image
+DELETE_LOCAL_IMAGE="${DELETE_LOCAL_IMAGE:-false}"
+
 gcloud auth configure-docker us-docker.pkg.dev --quiet
 
 COMMIT_HASH=$(git rev-parse --short HEAD)
@@ -80,3 +83,8 @@ docker build --no-cache \
 docker push us-docker.pkg.dev/${PROJECT_ID}/${CLOUD_IMAGE_NAME}/tpu:${FULL_IMAGE_TAG}
 
 echo "All done, check out your artifacts at: us-docker.pkg.dev/${PROJECT_ID}/${CLOUD_IMAGE_NAME}/tpu:${FULL_IMAGE_TAG}"
+
+if [ "$DELETE_LOCAL_IMAGE" == "true" ]; then
+  docker rmi us-docker.pkg.dev/${PROJECT_ID}/${CLOUD_IMAGE_NAME}/tpu:${FULL_IMAGE_TAG}
+  echo "Local image deleted."
+fi


### PR DESCRIPTION
* Amending the workflow to build MaxText with Jax-ss, which will then be used for XLML tests.
* Refactored to replace with JAX-Stable-Stack

Tested: 

https://github.com/google/maxtext/actions/runs/10049578143/job/27775886358?pr=796