### PR TITLE
Support ahead-of-time compilation on A3-generation GPU VMs

### DIFF
--- a/MaxText/accelerator_to_spec_map.py
+++ b/MaxText/accelerator_to_spec_map.py
@@ -21,16 +21,17 @@ IF YOU MODIFY THIS FILE YOU SHOULD ALSO ADD CORRESPONDING MODIFICATIONS TO
 UserFacingNameToSystemCharacteristics in xpk/xpk.py !!!!! """
 
 from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
 class SystemCharacteristics:
   platform: str
-  topology_name: str
-  chip_config_name: str  # 'megacore' or 'default'
-  chips_per_host_bounds: tuple
+  topology_name: Optional[str]
+  chip_config_name: Optional[str]  # 'megacore' or 'default'
+  chips_per_host_bounds: Optional[tuple]
   devices_per_slice: int
-  wrap: tuple
+  wrap: Optional[tuple]
 
 
 UserFacingNameToSystemCharacteristics = {
@@ -150,6 +151,11 @@ UserFacingNameToSystemCharacteristics = {
     "v5p-12288": SystemCharacteristics("tpu", "v5:16x16x24", "megacore", (2, 2, 1), 6144, (True, True, True)),
     "v5p-13824": SystemCharacteristics("tpu", "v5:12x24x24", "megacore", (2, 2, 1), 6912, (True, True, True)),
     "v5p-17920": SystemCharacteristics("tpu", "v5:16x20x28", "megacore", (2, 2, 1), 8960, (True, True, True)),
+    # A3 - H100. The chips within each host have high-speed interconnect, while communication
+    # across hosts will occur over DCN. This makes the "slice" topology of A3 fixed to a single host.
+    # To use AoT compilation with multihost, the `compile_topology_num_slices` flag should be
+    # specified to the number of hosts.
+    "a3": SystemCharacteristics("gpu", None, None, None, 8, None)
 }
 
 

--- a/MaxText/decode.py
+++ b/MaxText/decode.py
@@ -16,6 +16,7 @@
 
 import jax
 
+import max_utils
 import maxengine
 
 import os
@@ -70,4 +71,5 @@ if __name__ == "__main__":
   pyconfig.initialize(sys.argv)
   cfg = pyconfig.config
   validate_config(cfg)
+  max_utils.print_system_information()
   main(cfg)

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -211,6 +211,9 @@ def maybe_initialize_jax_distributed_system(raw_keys):
 
   For CPUs, we call jax.distributed.initialize() explicitly, with the specified arguments.
   """
+  if raw_keys["compile_topology"]:
+    # Don't initialize jax distributed with AOT compilation
+    return
   if is_gpu_backend(raw_keys):
     max_logging.log(
         "Attempting to initialize the jax distributed system for GPU backend..."
@@ -898,3 +901,10 @@ def print_mem_stats(label:str):
       print(f"\tUsing (GB) {used} / {limit} ({used/limit:%}) on {d}")
   except (RuntimeError, KeyError):
     print("\tMemstats unavailable.")
+
+def print_system_information():
+  """ Print system information of the current environment.
+  Note that this will initialize the JAX backend. """
+  max_logging.log(f"System Information: Jax Version: {jax.__version__}")
+  max_logging.log(f"System Information: Jaxlib Version: {jax.lib.__version__}")
+  max_logging.log(f"System Information: Jax Backend: {jax.lib.xla_bridge.get_backend().platform_version}")

--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -172,12 +172,6 @@ _config = None
 config = None
 
 
-def print_system_information():
-  max_logging.log(f"System Information: Jax Version: {jax.__version__}")
-  max_logging.log(f"System Information: Jaxlib Version: {jax.lib.__version__}")
-  max_logging.log(f"System Information: Jax Backend: {jax.lib.xla_bridge.get_backend().platform_version}")
-
-
 def _lists_to_tuples(l: list[Any]) -> Union[tuple[Any], list[Any]]:
   return tuple(_lists_to_tuples(x) for x in l) if isinstance(l, list) else l
 
@@ -348,9 +342,6 @@ class _HyperParameters:
       assert raw_keys['global_batch_size_to_train_on'] % raw_keys['num_pipeline_microbatches'] == 0, f"The global batch size ({raw_keys['global_batch_size_to_train_on']}) must be divisible by the number of microbatches ({raw_keys['num_pipeline_microbatches']})"
     else:
       raw_keys["using_pipeline_parallelism"] = False
-
-
-    print_system_information()
 
     # Write raw_keys to GCS before type conversions
     max_utils.write_config_raw_keys_for_gcs(raw_keys)

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -595,6 +595,7 @@ def main(argv: Sequence[str]) -> None:
   os.environ["TF_CPP_MIN_LOG_LEVEL"] = "0"
   os.environ["LIBTPU_INIT_ARGS"] = os.environ.get("LIBTPU_INIT_ARGS", "") + " --xla_tpu_spmd_rng_bit_generator_unsafe=true"
   pyconfig.initialize(argv)
+  max_utils.print_system_information()
   config = pyconfig.config
   validate_train_config(config)
   os.environ["TFDS_DATA_DIR"] = config.dataset_path

--- a/MaxText/train_compile.py
+++ b/MaxText/train_compile.py
@@ -56,14 +56,21 @@ def validate_config(config):
 def get_topology_mesh(config):
   """Get the target hardware devices, and create configured mesh with them"""
   target_hardware = accelerator_to_spec_map.get_system_characteristics(config.compile_topology)
-  topology_devices = get_topology_desc(
-      platform=target_hardware.platform,
-      topology_name=target_hardware.topology_name,
-      chip_config_name=target_hardware.chip_config_name,
-      chips_per_host_bounds=target_hardware.chips_per_host_bounds,
-      num_slices=config.compile_topology_num_slices,
-      wrap=target_hardware.wrap,
-  ).devices
+  if target_hardware.platform == 'gpu':
+    # Disable sharded autotuning. This is an optimization to distribute
+    # autotuning across the fleet, but can cause hangs with AoT compilation.
+    os.environ['XLA_FLAGS'] = os.environ.get('XLA_FLAGS', '') + ' --xla_gpu_shard_autotuning=false'
+    jax.config.update('mock_num_gpu_processes', config.compile_topology_num_slices)
+    topology_devices = jax.devices()
+  else:
+    topology_devices = get_topology_desc(
+        platform=target_hardware.platform,
+        topology_name=target_hardware.topology_name,
+        chip_config_name=target_hardware.chip_config_name,
+        chips_per_host_bounds=target_hardware.chips_per_host_bounds,
+        num_slices=config.compile_topology_num_slices,
+        wrap=target_hardware.wrap,
+    ).devices
   topology_device_mesh = max_utils.create_device_mesh(config, topology_devices)
   topology_mesh = Mesh(topology_device_mesh, config.mesh_axes)
   return topology_mesh
@@ -137,6 +144,10 @@ def main(argv: Sequence[str]) -> None:
 
   # Create target mesh
   topology_mesh = get_topology_mesh(config)
+
+  # Print system information after building the compile topology to avoid
+  # prematurely initializing the backend.
+  max_utils.print_system_information()
 
   # Get shaped inputs
   shaped_train_args, shaped_train_kwargs, state_mesh_annotations, model = get_shaped_inputs(topology_mesh, config)

--- a/README.md
+++ b/README.md
@@ -105,8 +105,12 @@ jsonPayload.verb="stacktraceanalyzer"
 
 Here is the related PyPI package: https://pypi.org/project/cloud-tpu-diagnostics.
 
-## Ahead of Time Compilation (AOT, tpu-only)
-To compile your training run ahead of time, we provide a tool `train_compile.py`. This tool allows you to compile the main `train_step` in `train.py` for target hardware (e.g. a large number of v5e devices) without using the target hardware, and instead you may use only a CPU or a single VM from a different family. This compilation helps with two main goals:
+## Ahead of Time Compilation (AOT)
+To compile your training run ahead of time, we provide a tool `train_compile.py`. This tool allows you to compile the main `train_step` in `train.py` for target hardware (e.g. a large number of v5e devices) without using the full cluster.
+
+### TPU Support
+
+You may use only a CPU or a single VM from a different family to pre-compile for a TPU cluster. This compilation helps with two main goals:
 
 * It will flag any out of memory (OOM) information, such as when the `per_device_batch_size` is set too high, with an identical OOM stack trace as if it was compiled on the target hardware.
 
@@ -114,7 +118,7 @@ To compile your training run ahead of time, we provide a tool `train_compile.py`
 
 The tool `train_compile.py` is tightly linked to `train.py` and uses the same configuration file `configs/base.yml`. Although you don't need to run on a TPU, you do need to install `jax[tpu]` in addition to other dependencies, so we recommend running `setup.sh` to install these if you have not already done so.
 
-### Example AOT 1: Compile ahead of time basics
+#### Example AOT 1: Compile ahead of time basics
 After installing the dependencies listed above, you are ready to compile ahead of time:
 ```
 # Run the below on a single machine, e.g. a CPU
@@ -124,7 +128,7 @@ global_parameter_scale=16 per_device_batch_size=4
 
 This will compile a 16B parameter MaxText model on 2 v5e pods.
 
-### Example AOT 2: Save compiled function, then load and run it
+#### Example AOT 2: Save compiled function, then load and run it
 Here is an example that saves then loads the compiled `train_step`, starting with the save:
 
 **Step 1: Run AOT and save compiled function**
@@ -150,6 +154,41 @@ base_output_directory=gs://my-output-bucket dataset_path=gs://my-dataset-bucket
 ```
 
 In the save step of example 2 above we included exporting the compiler flag `LIBTPU_INIT_ARGS` and `learning_rate` because those affect the compiled object `my_compiled_train.pickle.` The sizes of the model (e.g. `global_parameter_scale`, `max_sequence_length` and `per_device_batch`) are fixed when you initially compile via `compile_train.py`, you will see a size error if you try to run the saved compiled object with different sizes than you compiled with. However a subtle note is that the **learning rate schedule** is also fixed when you run `compile_train` - which is determined by both `steps` and `learning_rate`. The optimizer parameters such as  `adam_b1` are passed only as shaped objects to the compiler - thus their real values are determined when you run `train.py`, not during the compilation. If you do pass in different shapes (e.g. `per_device_batch`), you will get a clear error message reporting that the compiled signature has different expected shapes than what was input. If you attempt to run on different hardware than the compilation targets requested via `compile_topology`, you will get an error saying there is a failure to map the devices from the compiled to your real devices. Using different XLA flags or a LIBTPU than what was compiled will probably run silently with the environment you compiled in without error. However there is no guaranteed behavior in this case; you should run in the same environment you compiled in.
+
+### GPU Support
+Ahead-of-time compilation is also supported for GPUs with some differences from TPUs: 
+
+1. GPU does not support compilation across hardware: A GPU host is still required to run AoT compilation, but a single GPU host can compile a program for a larger cluster of the same hardware.
+
+1. For [A3 Cloud GPUs](https://cloud.google.com/compute/docs/gpus#h100-gpus), the maximum "slice" size is a single host, and the `compile_topology_num_slices` parameter represents the number of A3 machines to precompile for.
+
+#### Example
+This example illustrates the flags to use for a multihost GPU compilation targeting a cluster of 4 A3 hosts:
+
+**Step 1: Run AOT and save compiled function**
+```
+# Run the below on a single A3 machine
+export XLA_FLAGS="--xla_gpu_enable_async_collectives=true"
+python3 MaxText/train_compile.py MaxText/configs/base.yml compile_topology=a3 \
+compile_topology_num_slices=4 \
+compiled_trainstep_file=my_compiled_train.pickle global_parameter_scale=16 \
+attention=dot_product per_device_batch_size=4 steps=10000 learning_rate=1e-3
+```
+
+**Step 2: Run train.py and load the compiled function**
+
+To load the compiled train_step, you just need to pass `compiled_trainstep_file=my_compiled_train.pickle` into `train.py`:
+```
+# Run the below on each of the 4 target A3 hosts.
+export XLA_FLAGS="--xla_gpu_enable_async_collectives=true"
+python3 MaxText/train.py MaxText/configs/base.yml run_name=example_load_compile \
+compiled_trainstep_file=my_compiled_train.pickle \
+attention=dot_product global_parameter_scale=16  per_device_batch_size=4 steps=10000 learning_rate=1e-3 \
+base_output_directory=gs://my-output-bucket dataset_path=gs://my-dataset-bucket
+```
+
+As in the TPU case, note that the compilation environment must match the execution environment, in this case by setting the same `XLA_FLAGS`.
+
 
 ## Automatically Upload Logs to Vertex Tensorboard
 MaxText supports automatic upload of logs collected in a directory to a Tensorboard instance in Vertex AI. Follow [user guide](getting_started/Use_Vertex_AI_Tensorboard.md) to know more.

--- a/setup.sh
+++ b/setup.sh
@@ -151,9 +151,7 @@ elif [[ $MODE == "nightly" ]]; then
     if [[ $DEVICE == "gpu" ]]; then
         echo "Installing jax-nightly, jaxlib-nightly"
         # Install jax-nightly
-        pip3 install --pre -U jax -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
-        # Install jaxlib-nightly
-        pip3 install -U --pre jaxlib -f https://storage.googleapis.com/jax-releases/jaxlib_nightly_cuda12_releases.html
+        pip3 install --pre -U 'jax[cuda12]' -f https://storage.googleapis.com/jax-releases/jax_nightly_releases.html
         # Install Transformer Engine
         export NVTE_FRAMEWORK=jax
         pip3 install git+https://github.com/NVIDIA/TransformerEngine.git@stable


### PR DESCRIPTION
This change allows precompiling for A3 GPU clusters. AoT compilation for GPUs works slightly differently from TPU, since the compiler needs access to a physical device for compilation.