### PR TITLE
new features with distributed training framework

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -363,15 +363,15 @@ local_batch_size: 32
 prefetch_factor: 2
 # Number of data loader workers (per pod).
 data_loader_num_workers: 2
-# Number of seconds to sleep in between steps. This will not block prefetching.
-per_step_computation_time: 0.0
+# Number of seconds that represents a step interval. Default to 1 second.
+per_step_interval: 1.0
+# Stop training after this number of global steps. Default to -1, which means that the training
+# will instead be stopped by the epochs instead.
+max_steps: -1
 # The directory to which the dataset is stored.
 dataset_directory: "/mnt/gcsfuse"
 # The bucket that holds metrics gathered from each running pod.
 gcs_metrics_bucket: "distributed-training-metrics"
-### Parameters used for GCSFuse
-# The GCS bucket that holds the dataset.
-dataset_bucket: xai-hf-dataset-parquet
 # The strategy used for reading the dataset. The options for this field are specified by the keys of
 # `DATA_LOADER_STRATEGIES_BY_NAME` in MaxText/standalone_dataloader.py.
 data_loader_strategy_name: FileParallelSequentialRead

--- a/MaxText/deployment.yaml
+++ b/MaxText/deployment.yaml
@@ -21,14 +21,15 @@ spec:
   - metadata-cache:ttl-secs:-1
   - metadata-cache:stat-cache-max-size-mb:-1
   - metadata-cache:type-cache-max-size-mb:-1
-#  - file-system:kernel-list-cache-ttl-secs:-1
+  - file-system:kernel-list-cache-ttl-secs:-1
   - file-cache:max-size-mb:-1
-  - file-cache:cache-file-for-range-read:true
-  - file-cache:enable-parallel-downloads:true
+  - file-cache:cache-file-for-range-read:false
+  - file-cache:enable-parallel-downloads:false
   csi:
     driver: gcsfuse.csi.storage.gke.io
     volumeHandle: xai-hf-dataset-parquet # unique bucket name. xai-hf-dataset-parquet-10g for the 10G * 12K dataset.
     volumeAttributes:
+      # enableMetrics: "true"
       skipCSIBucketAccessCheck: "true"
 ---
 apiVersion: v1
@@ -62,8 +63,8 @@ spec:
       replicas: 1
       template:
         spec:
-          parallelism: 1024    # Equal to the number of VMs per slice
-          completions: 1024    # Same as the above.
+          parallelism: 64    # Equal to the number of VMs per slice
+          completions: 64    # Same as the above.
           backoffLimit: 0   # When any pod fails, the job is failed
           template:
             metadata:
@@ -79,28 +80,16 @@ spec:
               initContainers:
               # Metadata Prefetch native sidecar.
               - name: metadata-prefetch-container
-                image: alpine:3.20
+                image: ubuntu:22.04
                 restartPolicy: Always
                 command:
                 - "/bin/sh"
                 - "-c"
                 - |
-                  _term() { 
-                    echo "Caught SIGTERM signal: Terminating..." 
-                    kill -TERM "$child" 2>/dev/null
-                    exit 0
-                  }
-
-                  trap _term SIGTERM
-
-                  echo "Starting ls on the bucket..."
-                  # Redirect output to /dev/null to prevent storage of output.
-                  ls -R /mnt/gcsfuse > /dev/null && \
-                  echo "Metadata prefetch complete. Going to sleep..." && \
-                  sleep infinite &
-
-                  child=$! 
-                  wait "$child"
+                   echo "Starting ls on the bucket..."
+                   # Redirect output to /dev/null to prevent storage of output.
+                   echo "Metadata prefetch for /mnt/gcsfuse..." && ls -R /mnt/gcsfuse > /dev/null && echo "Metadata prefetch for /mnt/gcsfuse complete." &
+                   tail -f /dev/null
                 securityContext:
                   allowPrivilegeEscalation: false
                   capabilities:
@@ -138,7 +127,7 @@ spec:
               serviceAccountName: bernardhan-benchmark
               containers:
               - name: jax-cpu
-                image: gcr.io/gcs-tess/bernardhan_ckpt_runner_test
+                image: gcr.io/gcs-tess/bernardhan_test_n
                 
                 env: 
                 - name: REPLICATED_JOB_NAME
@@ -154,9 +143,9 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']
                 - name: PROCESSES_IN_JOB
-                  value: "1024"
+                  value: "64"
                 - name: JAX_PROCESS_COUNT
-                  value: "1024"
+                  value: "64"
                 
                 - name: JOBSET_NAME
                   value: "xpk-test-workload"
@@ -173,8 +162,8 @@ spec:
                 - bash
                 - -c
                 - |
-                  export COMMON_RUN_FLAGS="enable_checkpointing=False ici_data_parallelism=8 ici_fsdp_parallelism=128 hardware=cpu";
-                  export BENCHMARK_RUN_FLAGS="dataset_bucket=xai-hf-dataset-parquet epochs=2 local_batch_size=32 prefetch_factor=2 data_loader_num_workers=2 per_step_computation_time=0";
+                  export COMMON_RUN_FLAGS="enable_checkpointing=False hardware=cpu";
+                  export BENCHMARK_RUN_FLAGS="run_name=bernardhan-testing-new-step dataset_directory=/mnt/gcsfuse epochs=2 max_steps=100 local_batch_size=32 prefetch_factor=2 data_loader_num_workers=20 per_step_interval=1.0 data_loader_strategy_name=FileParallelSequentialRead gcs_metrics_bucket=distributed-training-metrics";
                   echo XPK Start: $(date) ; _sigterm() ( kill -SIGTERM $! 2>/dev/null;); trap _sigterm SIGTERM;(JAX_PLATFORMS=cpu python3 MaxText/standalone_dataloader.py MaxText/configs/base.yml ${BENCHMARK_RUN_FLAGS} ${COMMON_RUN_FLAGS}) & PID=$!; while kill -0 $PID 2>/dev/null; do sleep 5; done; wait $PID; EXIT_CODE=$? ;  echo XPK End: $(date); echo EXIT_CODE=$EXIT_CODE;
 
                 volumeMounts:

--- a/MaxText/deployment.yaml
+++ b/MaxText/deployment.yaml
@@ -1,5 +1,5 @@
-# Use Static provisioning to define a PV for Cloud Storage buckets.
-# https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/cloud-storage-fuse-csi-driver#provision-static.
+# Use Static provisioning to define a PV for GCSFuse: https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/cloud-storage-fuse-csi-driver#provision-static.
+# For other storage solutions, please define your own PV and PVC and prefill the volume with the datasets.
 apiVersion: v1
 kind: PersistentVolume
 metadata:
@@ -13,6 +13,8 @@ spec:
   storageClassName: gcsfuse-sc # dummy storage class
   claimRef:
     name: training-test-claim
+    # Running in the "default" namespace so you can submit to the local queue
+    # created in the default namespace.
     namespace: default
   mountOptions:
   - debug_fuse
@@ -29,7 +31,7 @@ spec:
     driver: gcsfuse.csi.storage.gke.io
     volumeHandle: xai-hf-dataset-parquet # unique bucket name. xai-hf-dataset-parquet-10g for the 10G * 12K dataset.
     volumeAttributes:
-      # enableMetrics: "true"
+      enableMetrics: "true"
       skipCSIBucketAccessCheck: "true"
 ---
 apiVersion: v1
@@ -49,6 +51,7 @@ spec:
 apiVersion: jobset.x-k8s.io/v1alpha2
 kind: JobSet
 metadata:
+  # Modify this name to distinguish your workload from others.
   name: xpk-test-workload
   labels:
     kueue.x-k8s.io/queue-name: multislice-queue  # Name of the LocalQueue
@@ -63,22 +66,26 @@ spec:
       replicas: 1
       template:
         spec:
-          parallelism: 64    # Equal to the number of VMs per slice
-          completions: 64    # Same as the above.
+          parallelism: 512    # Equal to the number of VMs per slice
+          completions: 512    # Same as the above.
           backoffLimit: 0   # When any pod fails, the job is failed
           template:
             metadata:
               labels:
                 xpk.google.com/workload: xpk-test-workload
-              annotations: # required for GCSFuse
+              # Required for GCSFuse.
+              # For other storage solutions, please modify this section.
+              annotations:
                 gke-gcsfuse/volumes: "true"
                 gke-gcsfuse/cpu-limit: "0"
                 gke-gcsfuse/memory-limit: "0"
                 gke-gcsfuse/ephemeral-storage-limit: "0"
-            
+
             spec:
               initContainers:
               # Metadata Prefetch native sidecar.
+              # Added to test the GCSfuse - Tuning and best practices for AI/ML workloads:
+              # https://docs.google.com/document/d/1NI64_qfTPBOQBmn_AOUwwFt7XQBQYrCqeLKIeKYkx5w/edit?tab=t.0#bookmark=id.i4mbb8t99ic2
               - name: metadata-prefetch-container
                 image: ubuntu:22.04
                 restartPolicy: Always
@@ -117,19 +124,23 @@ spec:
                         values:
                         - default-pool
 
+              # For GCSFuse: to make sure that the pods are running on nodes with L-SSDs.
+              # For other storage solutions that do not need L-SSDs, please remove this line.
               nodeSelector:
                 cloud.google.com/gke-ephemeral-storage-local-ssd: "true"
-                
+
               priorityClassName: medium
               hostNetwork: true
               dnsPolicy: ClusterFirstWithHostNet
               terminationGracePeriodSeconds: 30
+              # For GCSFuse: the setup of K8S SA is needed. https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/cloud-storage-fuse-csi-driver#authentication
+              # For other storage solutions that do not need the K8S SA, please remove this line.
               serviceAccountName: bernardhan-benchmark
               containers:
               - name: jax-cpu
-                image: gcr.io/gcs-tess/bernardhan_test_n
-                
-                env: 
+                image: gcr.io/gcs-tess/distributed_pytorch_training_benchmark
+
+                env:
                 - name: REPLICATED_JOB_NAME
                   valueFrom:
                     fieldRef:
@@ -142,16 +153,16 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']
+                # Modify the following two values too, if you intend to run the workload in smaller scale.
                 - name: PROCESSES_IN_JOB
-                  value: "64"
+                  value: "512"
                 - name: JAX_PROCESS_COUNT
-                  value: "64"
-                
+                  value: "512"
                 - name: JOBSET_NAME
                   value: "xpk-test-workload"
                 - name: JAX_COORDINATOR_ADDRESS
                   value: "$(JOBSET_NAME)-$(REPLICATED_JOB_NAME)-0-0.$(JOBSET_NAME)"
-  
+
                 ports:
                 - containerPort: 8471
                 - containerPort: 8080
@@ -162,15 +173,30 @@ spec:
                 - bash
                 - -c
                 - |
+                  # Modify the parameters here.
+                  export RUN_NAME="YOUR_RUN_NAME"
+                  export DATASET_DIRECTORY="/mnt/gcsfuse"
+                  export EPOCHS=2
+                  export MAX_STEPS=-1
+                  export LOCAL_BATCH_SIZE=32
+                  export PREFETCH_FACTOR=2
+                  export DATA_LOADER_NUM_WORKERS=10
+                  export PER_STEP_INTERVAL=0.1
+                  export DATA_LOADER_STRATEGY_NAME="FileParallelSequentialRead"
+                  export GCS_METRICS_BUCKET="distributed-training-metrics"
+
+                  # Not recommended to modify the flags below.
                   export COMMON_RUN_FLAGS="enable_checkpointing=False hardware=cpu";
-                  export BENCHMARK_RUN_FLAGS="run_name=bernardhan-testing-new-step dataset_directory=/mnt/gcsfuse epochs=2 max_steps=100 local_batch_size=32 prefetch_factor=2 data_loader_num_workers=20 per_step_interval=1.0 data_loader_strategy_name=FileParallelSequentialRead gcs_metrics_bucket=distributed-training-metrics";
+                  export BENCHMARK_RUN_FLAGS="run_name=${RUN_NAME} dataset_directory=${DATASET_DIRECTORY} epochs=${EPOCHS} max_steps=${MAX_STEPS} local_batch_size=${LOCAL_BATCH_SIZE} prefetch_factor=${PREFETCH_FACTOR} data_loader_num_workers=${DATA_LOADER_NUM_WORKERS} per_step_interval=${PER_STEP_INTERVAL} data_loader_strategy_name=${DATA_LOADER_STRATEGY_NAME} gcs_metrics_bucket=${GCS_METRICS_BUCKET}";
                   echo XPK Start: $(date) ; _sigterm() ( kill -SIGTERM $! 2>/dev/null;); trap _sigterm SIGTERM;(JAX_PLATFORMS=cpu python3 MaxText/standalone_dataloader.py MaxText/configs/base.yml ${BENCHMARK_RUN_FLAGS} ${COMMON_RUN_FLAGS}) & PID=$!; while kill -0 $PID 2>/dev/null; do sleep 5; done; wait $PID; EXIT_CODE=$? ;  echo XPK End: $(date); echo EXIT_CODE=$EXIT_CODE;
 
                 volumeMounts:
+                # For other storage solutions, please modify the mount path and specify it in the
+                # DATASET_DIRECTORY argument in the command above.
                 - mountPath: /mnt/gcsfuse
                   name: gcs-pvc
                   readOnly: true
-  
+
               volumes:
               - name: gcs-pvc
                 persistentVolumeClaim:

--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -261,6 +261,7 @@ def initialize_jax_for_cpu():
       coordinator_address=coordinator_address,
       process_id=pid,
       num_processes=int(os.environ.get("JAX_PROCESS_COUNT")),
+      initialization_timeout=3000,
   )
 
 

--- a/MaxText/torch_datasets/parquet.py
+++ b/MaxText/torch_datasets/parquet.py
@@ -34,6 +34,7 @@ class ParquetIterableDataset(abc.ABC, IterableDataset):
   """
   def __init__(self, allocated_parquet_files: Iterable[str], columns=None, batch_size=1000):
     max_logging.log(f'Using {self.__class__.__name__} strategy.')
+    max_logging.log(f'Allocated with the following data files: {allocated_parquet_files}.')
     self.allocated_parquet_files = allocated_parquet_files
     self.columns = columns
     self.batch_size = batch_size


### PR DESCRIPTION
## Features

1. Support of modeling `per_step_interval`.
2. Support of modeling `max_steps`.
3. Support of listing the dataset directory instead of hard-coding the bucket name from the run flags.

(1) and (2) are coming from the [design doc](https://docs.google.com/document/d/1YC9YuHaFpeTQ_5NXCfRfbr3j9y9w-JKcDiHQBSccKKI/edit?tab=t.0#heading=h.m86zlajb3moj). (3) is a bug identified from a conversation with the HNS team that the current hard-coded values prevent the benchmark from easily run against different bucket names.

Internal CL to update the README and the yaml file: cl/662264972.

## Tested by

1. Setting `per_step_interval` to 1 second and confirming that the per step time is roughly 1 second with the exception of those steps whose data loading time takes longer.
2. Setting `max_steps` to make sure that the training can stop gracefully after the global step is met, and that the metrics are recorded correctly.

## Next steps

1. Once this PR and the CL are merged, I'll build the image and upload to gcr.io/gcs-tess/distributed_pytorch_training_benchmark.
2. Once we start to move this to the new simpler framework, I'll add unit tests to cover the various features.