### PR TITLE
[MLPerf][GPT3] Bypass setting eval_interval in using synthetic dataset

### DIFF
--- a/MaxText/pyconfig.py
+++ b/MaxText/pyconfig.py
@@ -372,7 +372,8 @@ class _HyperParameters:
     raw_keys["learning_rate_schedule_steps"] = decay_end_step
     raw_keys["warmup_steps_fraction"] = warmup_steps / decay_end_step
     global_batch_size_to_train_on = calculate_global_batch_sizes(raw_keys)[1]
-    raw_keys["eval_interval"] = math.ceil(24567 / global_batch_size_to_train_on)
+    if raw_keys["dataset_type"] != "synthetic":
+      raw_keys["eval_interval"] = math.ceil(24567 / global_batch_size_to_train_on)
 
   @staticmethod
   def update_model_vars(base_config_path, raw_keys, config_name: str):


### PR DESCRIPTION
There's no eval_iterator in `dataset_type=synthetic` which is also not necessary.
https://github.com/google/maxtext/blob/77f079f845084ba853453dc0755deb0daf312e26/MaxText/input_pipeline/input_pipeline_interface.py#L144

 This change is to bypass setting eval_interval with `dataset_type=synthetic`, avoid the error in using an None evaluation iterator for eval step.
https://github.com/google/maxtext/blob/bdc4d8d6d4ab767d2c3ee52dbb465278111f2be9/MaxText/train.py#L567
