### PR TITLE
Add dispatch and combine masks for dropping

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -113,7 +113,7 @@ logits_dot_in_fp32: True  # whether to use fp32 in logits_dense or shared_embedd
 num_experts: 1
 num_experts_per_tok: 1
 megablox: True
-capacity_factor: -1 # a factor to decide expert capacity for token dropping, and no dropping by default
+capacity_factor: -1.0 # a factor to decide expert capacity for token dropping, and no dropping by default
 
 # pipeline parallelism
 # The number of decoder layers is equal to the product of num_stages, num_layers_per_pipeline_stage and num_pipeline_repeats.

--- a/MaxText/tests/moe_test.py
+++ b/MaxText/tests/moe_test.py
@@ -1,0 +1,98 @@
+#  Copyright 2024 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#       https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import jax
+import unittest
+from layers import linears
+from layers import initializers
+import jax.numpy as jnp
+
+import pyconfig
+import max_utils
+from jax.sharding import Mesh
+import flax.linen as nn
+
+
+class TokenDroppingTest(unittest.TestCase):
+
+  def setUp(self):
+    super().setUp()
+    pyconfig.initialize(
+      [None, 'configs/base.yml'],
+      run_name='moe_test',
+      enable_checkpointing=False,
+      model_name='mixtral-8x7b',
+      dtype='bfloat16',
+      megablox=False,
+      max_target_length=4,
+      per_device_batch_size=1,
+      capacity_factor=2,
+    )
+    self.cfg = pyconfig.config
+    self.rng = jax.random.PRNGKey(42)
+    devices_array = max_utils.create_device_mesh(self.cfg)
+    self.model = linears.MoeBlock(
+          config=self.cfg,
+          num_experts=self.cfg.num_experts,
+          num_experts_per_tok=self.cfg.num_experts_per_tok,
+          mesh=Mesh(devices_array, self.cfg.mesh_axes),
+          kernel_init=initializers.nd_dense_init(1.0, 'fan_in', 'truncated_normal'),
+          kernel_axes=('embed', 'mlp'),
+          dtype=self.cfg.dtype,
+      )
+
+  def test_generate_masks(self):
+    # expert_capacity = (tokens_per_batch / num_experts) * capacity_factor
+    # expert_capacity_in_batch = (4 * 2 / 8) * 2 = 2
+    top_k_indices = jnp.array([[[0, 5],[0, 4],[1, 0],[3, 5]],
+                               [[1, 2],[4, 1],[5, 0],[7, 1]],
+                               [[6, 2],[2, 3],[4, 2],[1, 2]],
+                               [[4, 1],[0, 7],[5, 0],[4, 7]]])
+    softmax_probs = jnp.array([[[0.20, 0.80],[0.68, 0.32],[0.78, 0.22],[0.32, 0.68]],
+                               [[0.26, 0.74],[0.21, 0.79],[0.11, 0.89],[0.89, 0.11]],
+                               [[0.74, 0.26],[0.88, 0.12],[0.83, 0.17],[0.35, 0.65]],
+                               [[0.53, 0.47],[0.36, 0.64],[0.85, 0.15],[0.18, 0.82]]])
+
+    # As expert_capacity_in_batch=2, so updated softmax_probs become (4 tokens were dropped):
+    # softmax_probs = jnp.array([[[0.20, 0.80],[0.68, 0.32],[0.78, 0],[0.32, 0.68]],
+    #                            [[0.26, 0.74],[0.21, 0.79],[0.11, 0.89],[0.89, 0]],
+    #                            [[0.74, 0.26],[0.88, 0.12],[0.83, 0],[0.35, 0]],
+    #                            [[0.53, 0.47],[0.36, 0.64],[0.85, 0.15],[0.18, 0.82]]])
+
+    # shape of dispatch_mask & combine_mask: (batch_size, seq_len, num_experts, expert_capacity_per_batch)
+    expected_combine_mask = jnp.array([[[[0.2,0],[0,0],[0,0],[0,0],[0,0],[0.8,0],[0,0],[0,0]],
+                                        [[0,0.68],[0,0],[0,0],[0,0],[0.32,0],[0,0],[0,0],[0,0]],
+                                        [[0,0],[0.78,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]],
+                                        [[0,0],[0,0],[0,0],[0.32,0],[0,0],[0,0.68],[0,0],[0,0]]],
+                                       [[[0,0],[0.26,0],[0.74,0],[0,0],[0,0],[0,0],[0,0],[0,0]],
+                                        [[0,0],[0,0.79],[0,0],[0,0],[0.21,0],[0,0],[0,0],[0,0]],
+                                        [[0.89,0],[0,0],[0,0],[0,0],[0,0],[0.11,0],[0,0],[0,0]],
+                                        [[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0.89,0]]],
+                                       [[[0,0],[0,0],[0.26,0],[0,0],[0,0],[0,0],[0.74,0],[0,0]],
+                                        [[0,0],[0,0],[0,0.88],[0.12,0],[0,0],[0,0],[0,0],[0,0]],
+                                        [[0,0],[0,0],[0,0],[0,0],[0.83,0],[0,0],[0,0],[0,0]],
+                                        [[0,0],[0.35,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0]]],
+                                       [[[0,0],[0.47,0],[0,0],[0,0],[0.53,0],[0,0],[0,0],[0,0]],
+                                        [[0.36,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0,0],[0.64,0]],
+                                        [[0,0.15],[0,0],[0,0],[0,0],[0,0],[0.85,0],[0,0],[0,0]],
+                                        [[0,0],[0,0],[0,0],[0,0],[0,0.18],[0,0],[0,0],[0,0.82]]]], dtype=jnp.float32)
+    expected_dispatch_mask = expected_combine_mask.astype(bool)
+    actual_dispatch_mask, actual_combine_mask = self.model.generate_masks(top_k_indices, softmax_probs)
+
+    self.assertTrue((expected_dispatch_mask == actual_dispatch_mask).all())
+    self.assertTrue(jax.numpy.allclose(expected_combine_mask, actual_combine_mask, rtol=1e-02, atol=1e-02))
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
# Description

* Add dispatch and combine masks for dropping & expert parallelism.
* Update subscript of einsum() in non-dropping to be consistent
* Next step - add load balance loss for dropping to balance the token distribution.

# Test

A single moe layer unit test to compare before & after reshape on different capacity factors - [one example](https://paste.googleplex.com/6114986465427456). 