### PR TITLE
Temporarily pin google-cloud-aiplatform to 1.61.0

### DIFF
--- a/constraints_gpu.txt
+++ b/constraints_gpu.txt
@@ -27,7 +27,7 @@ gast==0.4.0
 google-api-core==2.19.1
 google-auth==2.30.0
 google-auth-oauthlib==1.0.0
-google-cloud-aiplatform==1.56.0
+google-cloud-aiplatform==1.61.0
 google-cloud-appengine-logging==1.4.3
 google-cloud-audit-log==0.2.5
 google-cloud-bigquery==3.25.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ cloud-accelerator-diagnostics
 cloud-tpu-diagnostics
 datasets
 gcsfs
+google-cloud-aiplatform==1.61.0
 google-cloud-storage
 grain-nightly
 flax>=0.8.0


### PR DESCRIPTION
**Description:**

Temporarily pin google-cloud-aiplatform to 1.61.0

**Testing:**

Uploaded to Vertex AI Tensorboard and saw the data