### PR TITLE
Add load balance loss

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -114,6 +114,7 @@ num_experts: 1
 num_experts_per_tok: 1
 megablox: True
 capacity_factor: -1.0 # a factor to decide expert capacity for token dropping, and no dropping by default
+load_balance_loss_weight: 0.01 # weight for the load balance loss
 
 # pipeline parallelism
 # The number of decoder layers is equal to the product of num_stages, num_layers_per_pipeline_stage and num_pipeline_repeats.

--- a/MaxText/maxtext_utils.py
+++ b/MaxText/maxtext_utils.py
@@ -265,3 +265,23 @@ def apply_gradient_clipping(raw_grads, state, clipping_threshold):
     grads, _ = gradient_clip_transformation.update(raw_grads, state, None)
 
   return grads
+
+def get_nested_value(dictionary, nested_key, default=None):
+  """
+  Retrieves a value from a nested key in a dictionary.
+
+  Args:
+      dictionary: The dictionary to search in.
+      nested_key: A tuple representing the nested key, e.g., ('level1', 'level2', 'key').
+      default: The value to return if the nested key is not found.
+
+  Returns:
+      The value associated with the nested key, or the default value if not found.
+  """
+  current_level = dictionary
+
+  for key in nested_key:
+    if not isinstance(current_level, dict) or key not in current_level:
+      return default
+    current_level = current_level[key]
+  return current_level

--- a/MaxText/tests/maxtext_utils_test.py
+++ b/MaxText/tests/maxtext_utils_test.py
@@ -44,5 +44,34 @@ class TestGradientClipping(unittest.TestCase):
         for param_name, raw_value in raw_grads[maxtext_utils.OVERWRITE_WITH_GRADIENT].items():
             self.assertTrue(jnp.array_equal(raw_value, clipped_grads[maxtext_utils.OVERWRITE_WITH_GRADIENT][param_name]))
 
+class TestNestedValueRetrieval(unittest.TestCase):
+    def setUp(self):
+        self.test_dict = {
+            "level1": {
+                "level2": {
+                    "key": 0.1,
+                }
+            },
+            "empty_level": {}
+        }
+
+    def test_valid_nested_key(self):
+        nested_key = ("level1", "level2", "key")
+        expected_value = 0.1
+        result = maxtext_utils.get_nested_value(self.test_dict, nested_key, 0.0)
+        self.assertEqual(result, expected_value)
+
+    def test_invalid_nested_key(self):
+        nested_key = ("level1", "nonexistent", "key")
+        expected_value = 0.0
+        result = maxtext_utils.get_nested_value(self.test_dict, nested_key, 0.0)
+        self.assertEqual(result, expected_value)
+
+    def test_empty_level(self):
+        nested_key = ("empty_level", "key")
+        expected_value = None
+        result = maxtext_utils.get_nested_value(self.test_dict, nested_key)
+        self.assertEqual(result, expected_value)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
# Description

* add load balance loss to MoE dropping strategy.
* set default `load_balance_loss_weight` as 0.01 (from [paper](https://arxiv.org/pdf/2101.03961) that this value loads balance quickly without interfering the training loss)

# Test
local test on a small model size:
* training 100 steps without lb_loss (`capacity_factor=-1`): [baseline](https://screenshot.googleplex.com/7ScSLCMGZ3W9Kvi) - lb_loss=0
* training 100 steps with lb_loss (`capacity_factor=1`): [test](https://screenshot.googleplex.com/AFEHtmpoT3gT8oB) 