### PR TITLE
Improve tfds perf in multihost env

### DIFF
--- a/MaxText/input_pipeline/_input_pipeline_utils.py
+++ b/MaxText/input_pipeline/_input_pipeline_utils.py
@@ -100,20 +100,9 @@ class HFDataSource(grain.RandomAccessDataSource):
     if self.n_shards < (self.dataloading_host_count * self.num_threads):
       warnings.warn(f"WARNING: Inefficient dataloading. Your train or eval dataset contains {self.n_shards} shards, "
                       "smaller than number of host loading data. This is known to lead to inefficient dataloading. " 
-                      "Please reshard the data, or use a subset of hosts for dataloading by setting expansion_factor_real_data."
-                      "see https://github.com/google/maxtext/blob/main/getting_started/Data_Input_Pipeline.md#limitations--recommendations"
+                      "see https://github.com/google/maxtext/blob/main/getting_started/Data_Input_Pipeline.md#multihost-dataloading-best-practice"
                       )
       self.n_shards = self.dataloading_host_count * self.num_threads
-    elif self.n_shards % (self.dataloading_host_count * self.num_threads) > 0:
-      usable_shards = (
-          self.n_shards
-          // (self.dataloading_host_count * self.num_threads)
-          * (self.dataloading_host_count * self.num_threads)
-      )
-      warnings.warn(f"Dataset contains {self.n_shards} shards, but only {usable_shards} shards will be used."
-                    "Make (dataset shards) % (number of host loading data) == 0 to use all shards of data"
-                    "see https://github.com/google/maxtext/blob/main/getting_started/Data_Input_Pipeline.md#limitations--recommendations"
-                    )
 
   def _update_shard(self, idx):
     new_shard = self.dataset_shards[idx] + self.dataloading_host_count * self.num_threads

--- a/MaxText/standalone_dataloader.py
+++ b/MaxText/standalone_dataloader.py
@@ -66,7 +66,7 @@ def main(argv: Sequence[str]) -> None:
   max_logging.log(f"Found {jax.device_count()} devices.")
   max_logging.log(f"Found {jax.process_count()} processes.")
   max_logging.log(f"Found {jax.devices()} devices.")
-  if config.dataset_type == 'tfds':
+  if config.dataset_type in ('tfds', 'c4_mlperf'):
     os.environ["TFDS_DATA_DIR"] = config.dataset_path
   data_load_loop(config)
 

--- a/getting_started/Data_Input_Perf.md
+++ b/getting_started/Data_Input_Perf.md
@@ -32,4 +32,4 @@ The following data are collected using c4 data in TFRecord format.
 | Pipeline    | seq_len | VM type    | per_host_batch    | # of host | # of batch | first step (s) | total time (s) |
 | ----------- | ------- | ---------- | ----------------- | --------- | ---------- | -------------  | -------------- |
 | TFDS        | 2048    | TPU v4-8   | 32 (per_device=8) | 1         | 1000       | 2              | 17             |
-| TFDS        | 2048    | TPU v4-128 | 32 (per_device=8) | 16        | 1000       | 3              | 66             |
+| TFDS        | 2048    | TPU v4-128 | 32 (per_device=8) | 16        | 1000       | 3              | 18             |


### PR DESCRIPTION
Have each host read a subset of data file in TFDS (already used by mlperf on mlperf/4.1 branch when dataset_type=c4_mlperf, credits to @ZhiyuLi-goog ) and document data input best practice