### PR TITLE
Add MaxText run name to TensorBoard file directory

### DIFF
--- a/MaxText/max_utils.py
+++ b/MaxText/max_utils.py
@@ -100,8 +100,9 @@ def summarize_size_from_pytree(params):
 
 
 def initialize_summary_writer(config):
+  summary_writer_path = os.path.join(config.tensorboard_dir, config.run_name)
   return (
-      writer.SummaryWriter(config.tensorboard_dir)
+      writer.SummaryWriter(summary_writer_path)
       if jax.process_index() == 0
       else None
   )


### PR DESCRIPTION
### Notes

Include run name in the TensorBoard subdirectory.

- Old path: gs://<base_output_directory>/<run_name>/tensorboard/
- New path: gs://<base_output_directory>/<run_name>/tensorboard/<run_name>

This allows run names to show up properly in Vertex AI/TB and local TB.

![Screenshot 2024-09-03 at 4 00 56 PM](https://github.com/user-attachments/assets/eb1ddbce-6d8f-42d4-92ec-bf1a1f4e0be6)

### Testing

- Ran MaxText through XPK and viewed managed/local TB
- Ran MaxText from TPU VM and viewed managed/local TB

### Next Steps

- Update run name prefix in cloud-accelerator-diagnostics package to get slightly better UI
- Add Vertex AI experiment name config option in MaxText. This is for uploading different runs to the same experiment from TPU VM. This option already exists on XPK