### PR TITLE
Make running preflight optional in model scripts

### DIFF
--- a/MaxText/configs/v4/22b.sh
+++ b/MaxText/configs/v4/22b.sh
@@ -32,6 +32,7 @@ echo "Running 22b.sh"
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -48,7 +49,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"

--- a/MaxText/configs/v4/52b.sh
+++ b/MaxText/configs/v4/52b.sh
@@ -32,6 +32,7 @@ echo "Running 52b.sh"
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -48,7 +49,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_enable_async_all_gather=true TPU_MEGACORE=MEGACORE_DENSE"

--- a/MaxText/configs/v5e/128b.sh
+++ b/MaxText/configs/v5e/128b.sh
@@ -18,6 +18,7 @@ echo "Running 128b.sh"
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -34,7 +35,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"

--- a/MaxText/configs/v5e/16b.sh
+++ b/MaxText/configs/v5e/16b.sh
@@ -18,6 +18,7 @@ echo "Running 16b.sh"
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -34,7 +35,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"

--- a/MaxText/configs/v5e/32b.sh
+++ b/MaxText/configs/v5e/32b.sh
@@ -18,6 +18,7 @@ echo "Running 32b.sh"
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -34,7 +35,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"

--- a/MaxText/configs/v5e/64b.sh
+++ b/MaxText/configs/v5e/64b.sh
@@ -18,6 +18,7 @@ echo "Running 64b.sh"
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -34,7 +35,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"

--- a/MaxText/configs/v5e/gpt3_175b.sh
+++ b/MaxText/configs/v5e/gpt3_175b.sh
@@ -17,6 +17,7 @@
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -33,7 +34,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true --xla_tpu_spmd_rng_bit_generator_unsafe=true"

--- a/MaxText/configs/v5e/llama2_13b.sh
+++ b/MaxText/configs/v5e/llama2_13b.sh
@@ -17,6 +17,7 @@
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -33,7 +34,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"

--- a/MaxText/configs/v5e/llama2_70b.sh
+++ b/MaxText/configs/v5e/llama2_70b.sh
@@ -17,6 +17,7 @@
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -33,7 +34,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"

--- a/MaxText/configs/v5e/llama2_7b.sh
+++ b/MaxText/configs/v5e/llama2_7b.sh
@@ -17,6 +17,7 @@
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -33,7 +34,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"

--- a/MaxText/configs/v5p/1024b.sh
+++ b/MaxText/configs/v5p/1024b.sh
@@ -18,6 +18,7 @@ echo "Running 1024b.sh"
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -34,7 +35,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"

--- a/MaxText/configs/v5p/128b.sh
+++ b/MaxText/configs/v5p/128b.sh
@@ -18,6 +18,7 @@ echo "Running 128b.sh"
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -34,7 +35,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"

--- a/MaxText/configs/v5p/256b.sh
+++ b/MaxText/configs/v5p/256b.sh
@@ -19,6 +19,7 @@ echo "Running 256b.sh"
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -35,7 +36,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"

--- a/MaxText/configs/v5p/32b.sh
+++ b/MaxText/configs/v5p/32b.sh
@@ -18,6 +18,7 @@ echo "Running 32b.sh"
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -34,7 +35,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"

--- a/MaxText/configs/v5p/512b.sh
+++ b/MaxText/configs/v5p/512b.sh
@@ -19,6 +19,7 @@ echo "Running 512b.sh"
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -35,7 +36,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"

--- a/MaxText/configs/v5p/64b.sh
+++ b/MaxText/configs/v5p/64b.sh
@@ -18,6 +18,7 @@ echo "Running 64b.sh"
 set -e
 
 export EXECUTABLE="train.py" # or train_compile.py
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -34,7 +35,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"

--- a/MaxText/configs/v5p/llama2_7b.sh
+++ b/MaxText/configs/v5p/llama2_7b.sh
@@ -21,6 +21,7 @@ set -e
 export EXECUTABLE="train.py" # or train_compile.py
 export DATASET_TYPE="synthetic" # synthetic data by default
 export REUSE_EXAMPLE_BATCH=1
+export RUN_PREFLIGHT="true"
 
 # Set environment variables
 for ARGUMENT in "$@"; do
@@ -37,7 +38,9 @@ then
 fi
 
 # Set up network optimizations
-bash preflight.sh
+if [ "$RUN_PREFLIGHT" = "true" ]; then
+    bash preflight.sh
+fi
 
 # Train
 export LIBTPU_INIT_ARGS="--xla_tpu_enable_async_collective_fusion_fuse_all_gather=true --xla_tpu_megacore_fusion_allow_ags=false --xla_enable_async_collective_permute=true --xla_tpu_enable_ag_backward_pipelining=true --xla_tpu_enable_data_parallel_all_reduce_opt=true --xla_tpu_data_parallel_opt_different_sized_ops=true --xla_tpu_enable_async_collective_fusion=true --xla_tpu_enable_async_collective_fusion_multiple_steps=true --xla_tpu_overlap_compute_collective_tc=true --xla_enable_async_all_gather=true"


### PR DESCRIPTION
Make running `preflight.sh` optional in model scripts. This is needed so that these scripts can be ran in nightly pathways tests since rto setup does not work with pathways.