### PR TITLE
remove attention type from gemma2 model configs

### DIFF
--- a/MaxText/configs/models/gemma2-27b.yml
+++ b/MaxText/configs/models/gemma2-27b.yml
@@ -25,7 +25,6 @@ vocab_size: 256128
 decoder_block: "gemma2"
 normalization_layer_epsilon: 1.e-06
 logits_via_embedding: True
-attention: "dot_product"
 final_logits_soft_cap: 30.0
 attn_logits_soft_cap: 50.0
 sliding_window_size: 4096

--- a/MaxText/configs/models/gemma2-2b.yml
+++ b/MaxText/configs/models/gemma2-2b.yml
@@ -25,7 +25,6 @@ vocab_size: 256128
 decoder_block: "gemma2"
 normalization_layer_epsilon: 1.e-06
 logits_via_embedding: True
-attention: "dot_product"
 final_logits_soft_cap: 30.0
 attn_logits_soft_cap: 50.0
 sliding_window_size: 4096

--- a/MaxText/configs/models/gemma2-9b.yml
+++ b/MaxText/configs/models/gemma2-9b.yml
@@ -25,7 +25,6 @@ vocab_size: 256128
 decoder_block: "gemma2"
 normalization_layer_epsilon: 1.e-06
 logits_via_embedding: True
-attention: "dot_product"
 final_logits_soft_cap: 30.0
 attn_logits_soft_cap: 50.0
 sliding_window_size: 4096


### PR DESCRIPTION
The default gemma2 configs have a preset attention type. This disallows users to override the attention type flag (e.g. use FlashAttention instead). Hence, we are removing the attention_type from the Gemma2 configs. 