### PR TITLE
Disable AOT activation offload test

### DIFF
--- a/MaxText/tests/train_compile_test.py
+++ b/MaxText/tests/train_compile_test.py
@@ -52,7 +52,8 @@ class TrainCompile(unittest.TestCase):
         "base_num_decoder_layers=2",
     ))
 
-  @pytest.mark.tpu
+  # TODO (b/366200617) : This tests fails in AOT, but config works fine on real hardware
+  @pytest.mark.skip(reason="Issue w/ kernels_test. Error: The TPU is already in use by process...")
   def test_minimal_offloaded_v5e(self):
     compiled_trainstep_file = "/tmp/test_compiled_v5e_offload.pickle"
     train_compile_main((


### PR DESCRIPTION
Test failing with new jax release - will disable for now while we investigate and fix

Although this AOT test fails with OOM that the tensor is in HBM instead of host, runs on real hardware work fine, activations are offloaded to host.

Internal tracking: b/366200617