### PR TITLE
Add precision option

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -67,6 +67,9 @@ dtype: "bfloat16"
 # 'intmp' for mixed precision weight only quantization based on config file
 # 'fp8' for 8-bit floating-point GeMMs on NVIDIA GPUs.
 quantization: ""
+# Choose one of default, high, and highest.
+# https://kolonist26-jax-kr.readthedocs.io/en/latest/jax.lax.html#jax.lax.Precision
+matmul_precision: "default"
 # Path to file with quantization config - only used for mixed precision.
 # Example configs in ../Maxtext/configs/quantization
 # Allows us to configure different bits, tiling and scale for quantizing selected weights.

--- a/MaxText/layers/attentions.py
+++ b/MaxText/layers/attentions.py
@@ -1040,6 +1040,7 @@ class Attention(nn.Module):
         weight_dtype=self.weight_dtype,
         name="query",
         quant=self.quant,
+        matmul_precision=self.config.matmul_precision,
     )(inputs_q)
     return query_proj
 
@@ -1071,6 +1072,7 @@ class Attention(nn.Module):
         weight_dtype=self.weight_dtype,
         name=proj_name,
         quant=self.quant,
+        matmul_precision=self.config.matmul_precision,
     )(inputs_kv)
     return kv_proj
 
@@ -1086,6 +1088,7 @@ class Attention(nn.Module):
         weight_dtype=self.weight_dtype,
         name=proj_name,
         quant=self.quant,
+        matmul_precision=self.config.matmul_precision,
     )(inputs)
     qkv_proj = checkpoint_name(qkv_proj, "qkv_proj")
     query, key, value = qkv_proj[:, :, 0, ...], qkv_proj[:, :, 1, ...], qkv_proj[:, :, 2, ...]
@@ -1101,6 +1104,7 @@ class Attention(nn.Module):
         weight_dtype=self.weight_dtype,
         name="out",
         quant=self.quant,
+        matmul_precision=self.config.matmul_precision,
     )(out)
     return out_proj
 

--- a/MaxText/layers/gpt3.py
+++ b/MaxText/layers/gpt3.py
@@ -167,6 +167,7 @@ class Gpt3MultiHeadAttention(nn.Module):
         name=proj_name,
         quant=self.quant,
         use_bias=self.use_bias,
+        matmul_precision=self.config.matmul_precision,
     )(inputs)
     qkv_proj = checkpoint_name(qkv_proj, "qkv_proj")
     query, key, value = qkv_proj[:, :, 0, ...], qkv_proj[:, :, 1, ...], qkv_proj[:, :, 2, ...]
@@ -184,6 +185,7 @@ class Gpt3MultiHeadAttention(nn.Module):
         name=proj_name,
         quant=self.quant,
         use_bias=self.use_bias,
+        matmul_precision=self.config.matmul_precision,
     )(inputs)
     return proj
 
@@ -199,6 +201,7 @@ class Gpt3MultiHeadAttention(nn.Module):
         name="out",
         quant=self.quant,
         use_bias=self.use_bias,
+        matmul_precision=self.config.matmul_precision,
     )(out)
     return out_proj
 

--- a/MaxText/layers/models.py
+++ b/MaxText/layers/models.py
@@ -397,6 +397,7 @@ class Decoder(nn.Module):
           dtype=jnp.float32 if cfg.logits_dot_in_fp32 else cfg.dtype,  # for logit training stability
           kernel_axes=("embed", "vocab"),
           name="logits_dense",
+          matmul_precision=self.config.matmul_precision,
       )(
           y
       )  # We do not quantize the logits matmul.


### PR DESCRIPTION
# Description

* Cast to f32 before element wise option 
* Add precision option to matmul 
   * JAX [precision](https://kolonist26-jax-kr.readthedocs.io/en/latest/jax.lax.html#jax.lax.Precision), and we currently used default
   * Instead of adding precision to each dot_general or einsum(), we could use [default_matmul_precision](https://kolonist26-jax-kr.readthedocs.io/en/latest/_autosummary/jax.default_matmul_precision.html), which has similar 3 options. However I met issues during flash attention kernel call ([here](https://screenshot.googleplex.com/5AQCzosPWabC48R)). So fall back to add precision to each matmul.


# Test
* base Mixtral 8x7b run (without changes, dtype=bfloat16, weight=f32): [link](https://screenshot.googleplex.com/vXCZbSe4keki2cb) - 2637.763 tokens/s/chip
* base Mixtral 8x7b run (with changes, dtype=bfloat16, weight=f32): [link](https://screenshot.googleplex.com/7joF6i2rJsJESG6) - 2625.901 tokens/s/chip (0.5% regression)
* matmul_precision=float32 run (with changes, dtype=bfloat16, weight=f32): [link](https://screenshot.googleplex.com/9Tbkr9AiZxzzvQe) - 2588.229  tokens/s/chip (1.88% regression)
* matmul_precision=float32 run (with changes, dtype=f32, weight=f32): OOM 14GB [link](https://screenshot.googleplex.com/BjxbExFeAHu2k2J) - makes sense