### PR TITLE
Add configs for Attention Block Size tuning

### DIFF
--- a/MaxText/configs/base.yml
+++ b/MaxText/configs/base.yml
@@ -432,3 +432,10 @@ allow_split_physical_axes: False
 
 use_ragged_attention: False
 ragged_block_size: 256
+
+### Splash attention block sizes
+# These can be tuned for specific hardware generations, and can be set up to
+# the model's sequence length.
+sa_block_q: 512
+sa_block_q_dkv: 512
+sa_block_q_dq: 512

--- a/MaxText/layers/gpt3.py
+++ b/MaxText/layers/gpt3.py
@@ -233,6 +233,7 @@ class Gpt3MultiHeadAttention(nn.Module):
     value = checkpoint_name(value, "value_proj")
 
     attention_op = AttentionOp(
+        config=self.config,
         mesh=self.mesh,
         attention_kernel=self.attention_kernel,
         max_target_length=self.max_target_length,

--- a/MaxText/train.py
+++ b/MaxText/train.py
@@ -23,7 +23,6 @@ limitations under the License.
 import datetime
 import os
 import sys
-from etils import epath
 import functools
 import time
 


### PR DESCRIPTION
Add attention block size tuning options to MaxText config. We see 1->2% MFU improvement across models on Trillium that tune these parameters. They can be sized up to sequence length.